### PR TITLE
Match annotations defined in parts, add relevant unit tests

### DIFF
--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -122,18 +122,20 @@ bool matchAnnotation(Type annotationType, ElementAnnotationImpl annotation) {
     return false;
   }
 
-  var annotationSource = annotationValueType.element.source as FileBasedSource;
+  var annotationLibSource =
+      annotationValueType.element.library.source as FileBasedSource;
 
   var libOwnerUri = (classMirror.owner as LibraryMirror).uri;
-  var annotationSourceUri = annotationSource.uri;
+  var annotationLibSourceUri = annotationLibSource.uri;
 
-  if (annotationSourceUri.scheme == 'file' && libOwnerUri.scheme == 'package') {
+  if (annotationLibSourceUri.scheme == 'file' &&
+      libOwnerUri.scheme == 'package') {
     // try to turn the libOwnerUri into a file uri
 
     libOwnerUri = _fileUriFromPackageUri(libOwnerUri);
   }
 
-  return annotationSource.uri == libOwnerUri;
+  return annotationLibSource.uri == libOwnerUri;
 }
 
 Uri _fileUriFromPackageUri(Uri libraryPackageUri) {

--- a/test/annotation_test.dart
+++ b/test/annotation_test.dart
@@ -186,29 +186,38 @@ void main() {
         expect(matched, isTrue);
       });
 
+      test('not annotated with specified class', () {
+        var annotatedClass =
+            _getAnnotationForClass(libElement, 'OtherClassCtorNoParams');
+        var annotation = annotatedClass.metadata.single;
+        var matched = matchAnnotation(defs.PublicAnnotationClass, annotation);
+        expect(matched, isFalse, reason: 'not annotated with that type');
+      });
+
       test('annotated with class in a part', () {
         ClassElement annotatedClass =
+            _getAnnotationForClass(libElement, 'CtorNoParamsFromPartInPart');
+        var annotation = annotatedClass.metadata.single;
+        var matched =
+            matchAnnotation(defs.PublicAnnotationClassInPart, annotation);
+        expect(matched, isTrue);
+      });
+
+      test('class in a part annotated with class', () {
+        var annotatedClass =
             _getAnnotationForClass(libElement, 'CtorNoParamsInPart');
         var annotation = annotatedClass.metadata.single;
         var matched = matchAnnotation(defs.PublicAnnotationClass, annotation);
         expect(matched, isTrue);
       });
 
-      test('class in a part annotated with class', () {
-        var annotatedClass = _getAnnotationForClass(libElement, 'CtorNoParams');
-        var annotation = annotatedClass.metadata.single;
-        var matched =
-            matchAnnotation(defs.PublicAnnotationClassInPart, annotation);
-        expect(matched, isFalse, reason: 'not annotated with that type');
-      });
-
       test('class in a part annotated with class in a part', () {
         ClassElement annotatedClass =
-            _getAnnotationForClass(libElement, 'CtorNoParamsInPart');
+            _getAnnotationForClass(libElement, 'CtorNoParamsFromPartInPart');
         var annotation = annotatedClass.metadata.single;
         var matched =
             matchAnnotation(defs.PublicAnnotationClassInPart, annotation);
-        expect(matched, isFalse);
+        expect(matched, isTrue);
       });
 
       test('class annotated with type defined via package uri', () {

--- a/test/test_files/annotated_classes.dart
+++ b/test/test_files/annotated_classes.dart
@@ -13,6 +13,12 @@ const PublicAnnotationClass localTypedAnnotation =
 @PublicAnnotationClass()
 class CtorNoParams {}
 
+@OtherPublicAnnotationClass()
+class OtherClassCtorNoParams {}
+
+@PublicAnnotationClassInPart()
+class CtorNoParamsFromPart {}
+
 @PublicAnnotationClass.withAnIntAsOne()
 class NonDefaultCtorNoParams {}
 

--- a/test/test_files/annotated_classes_part.dart
+++ b/test/test_files/annotated_classes_part.dart
@@ -7,3 +7,6 @@ const PublicAnnotationClass localTypedAnnotationInPart =
 
 @PublicAnnotationClass()
 class CtorNoParamsInPart {}
+
+@PublicAnnotationClassInPart()
+class CtorNoParamsFromPartInPart {}

--- a/test/test_files/annotations.dart
+++ b/test/test_files/annotations.dart
@@ -54,6 +54,10 @@ class PublicAnnotationClass {
         child2 = const PublicAnnotationClass.withAnIntAsOne();
 }
 
+class OtherPublicAnnotationClass {
+  const OtherPublicAnnotationClass();
+}
+
 const objectAnnotation = const {
   'int': 1,
   'bool': true,


### PR DESCRIPTION
#### Ultimate Problem
Annotations defined in parts of libraries are not matched by generators, which is unexpected behavior. (Annotations shouldn't always have to be defined in a main library file.)

#### Changes
* Match annotations based on equality between owner library URI and source _library_ uri, as opposed to owner library uri and source _file_ URI.
* Update tests.

