### PR TITLE
Add null aware operator before calling toList.

### DIFF
--- a/lib/generators/json_serializable_generator.dart
+++ b/lib/generators/json_serializable_generator.dart
@@ -211,7 +211,7 @@ String _writeAccessToVar(String varExpression, DartType searchType,
         ")";
 
     if (_isDartList(searchType)) {
-      output += ".toList()";
+      output += "?.toList()";
     }
 
     return output;


### PR DESCRIPTION
If a list type is null, the call to map() is prevented, but toList() is still called resulting in a NPE.