### PR TITLE
Add "jsonKey" annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.7
+
+* Add `JsonKey` annotation
+
 ## 0.4.6-dev
 
 * Improved output of generation errors and stack traces.

--- a/lib/generators/json_serializable.dart
+++ b/lib/generators/json_serializable.dart
@@ -15,3 +15,12 @@ class JsonSerializable {
       : this.createFactory = createFactory,
         this.createToJson = createToJson;
 }
+
+/// Customizes the name of the JSON key for a field.
+///
+/// If ommitted, the resulting JSON key will be the
+/// name of the field defined on the class.
+class JsonKey {
+  final String jsonName;
+  const JsonKey(this.jsonName);
+}

--- a/test/json_serializable_test.dart
+++ b/test/json_serializable_test.dart
@@ -100,6 +100,14 @@ void main() {
       expect(output, contains('json[\'children\']?.map('));
     });
   });
+
+  test('reads JsonKey annotations', () async {
+    var element = await _getClassForCodeString('Person');
+    var output = await _generator.generate(element);
+
+    expect(output, contains("'h': height,"));
+    expect(output, contains("..height = json['h']"));
+  });
 }
 
 const _generator = const JsonSerializableGenerator();
@@ -144,6 +152,7 @@ void annotatedMethod() => null;
 @JsonSerializable()
 class Person {
   String firstName, lastName;
+  @JsonKey("h")
   int height;
   DateTime dateOfBirth;
   dynamic dynamicType;


### PR DESCRIPTION
This fixes #65.
This adds the ability to specify a `JsonKey` annotation:
```dart
@JsonSerializable()
class MyClass {
  @JsonKey("foo")
  final int FooBar;
  ...
```

source_gen then uses that value for the key when serializing to JSON: 

```json
{
    "foo": 123
}
```

FYI @kevmoo 