### PR TITLE
Use pkg/resource to find paths

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.4.8
+version: 0.4.9-dev
 author: Dart Team <misc@dartlang.org>
 description: Automatic sourcecode generation for Dart
 homepage: https://github.com/dart-lang/source_gen
@@ -14,5 +14,6 @@ dependencies:
 dev_dependencies:
   collection: ^1.1.2
   mockito: ^0.11.0
+  resource: ^1.1.0
   scheduled_test: ^0.12.0
   test: ^0.12.3

--- a/test/annotation_test.dart
+++ b/test/annotation_test.dart
@@ -24,6 +24,10 @@ import 'test_files/annotations.dart' as defs;
 import 'test_utils.dart';
 
 void main() {
+  setUpAll(() async {
+    await populatePackagePath();
+  });
+
   LibraryElement libElement;
 
   setUp(() async {

--- a/test/find_libraries_test.dart
+++ b/test/find_libraries_test.dart
@@ -15,6 +15,10 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
+  setUpAll(() async {
+    await populatePackagePath();
+  });
+
   group('check source files against expected libraries', () {
     AnalysisContext context;
 

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -16,6 +16,10 @@ import 'package:source_gen/src/io.dart';
 import 'test_utils.dart';
 
 void main() {
+  setUpAll(() async {
+    await populatePackagePath();
+  });
+
   test('expandFileListToIncludePeers', () {
     var examplePath = p.join(getPackagePath(), 'example');
     var jsonPath = p.join(examplePath, 'data.json');

--- a/test/json_serializable_test.dart
+++ b/test/json_serializable_test.dart
@@ -22,6 +22,10 @@ import 'package:source_gen/generators/json_serializable_generator.dart';
 import 'test_utils.dart';
 
 void main() {
+  setUpAll(() async {
+    await populatePackagePath();
+  });
+
   group('non-classes', () {
     test('const field', () async {
       var element = await _getClassForCodeString('theAnswer');

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -15,6 +15,10 @@ import 'package:source_gen/src/utils.dart';
 import 'test_utils.dart';
 
 void main() {
+  setUpAll(() async {
+    await populatePackagePath();
+  });
+
   group('libraries for files', () {
     AnalysisContext ctx;
 


### PR DESCRIPTION
The async-ness of the API hurts a bit.

But it feels less broken than using mirrors.