### PR TITLE
Fix multiline error output for more than two lines of error message.

### DIFF
--- a/lib/src/generated_output.dart
+++ b/lib/src/generated_output.dart
@@ -54,6 +54,7 @@ void _commentWithHeader(String header, String content, StringSink buffer) {
   var blankPrefix = ''.padLeft(header.length, ' ');
   for (var i = 1; i < lines.length; i++) {
     buffer.writeAll([_commentPrefix, blankPrefix, lines[i]]);
+    buffer.writeln();
   }
 }
 


### PR DESCRIPTION
Currently lines after the second one are concatenated without newlines, leading to error output like:

// Error: first line of error message.
//        Second line of error message. //        Third line of error message.        // Fourth line of error message.