### PR TITLE
Use library URI (not name) to look up annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2-dev
+
+* Use library URIs (not names) to look up annotations in the mirror system.
+
 ## 0.5.1+7
 
 * Generate valid strong-mode code for typed lists.

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -192,9 +192,22 @@ DeclarationMirror _getDeclarationMirrorFromType(InterfaceType type) {
   var system = currentMirrorSystem();
 
   // find library
-  var libElement = type.element.library;
-  var libNameSymbol = new Symbol(libElement.name);
-  var libMirror = system.findLibrary(libNameSymbol);
+  var libraryUri = type.element.library.librarySource.uri;
+
+  if (libraryUri.scheme == 'asset') {
+    // see if it looks like a package
+    var segs = libraryUri.pathSegments.toList();
+    if (segs.length >= 2 && segs[1] == 'lib') {
+      segs.removeAt(1);
+      libraryUri = new Uri(scheme: 'package', pathSegments: segs);
+    } else {
+      // TODO: we should support this. Just would take some time.
+      throw new UnsupportedError('Generator annotations must be defined within '
+          'a package lib directory.');
+    }
+  }
+
+  var libMirror = system.libraries[libraryUri];
 
   // find class symbol
   var typeNameSymbol = new Symbol(type.name);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.5.1+7
+version: 0.5.2-dev
 author: Dart Team <misc@dartlang.org>
 description: Automatic sourcecode generation for Dart
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
Fixes https://github.com/dart-lang/source_gen/issues/100