### PR TITLE
Fix check for implemented interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Use library URIs (not names) to look up annotations in the mirror system.
 * Loosen version constraint to allow package:build version 0.6
+* Fix a bug against the latest SDK checking whether List implements Iterable
 
 ## 0.5.1+7
 

--- a/lib/generators/json_serializable_generator.dart
+++ b/lib/generators/json_serializable_generator.dart
@@ -278,15 +278,10 @@ ParameterizedType _typeTest(
   if (tester(type)) return type;
 
   if (type is InterfaceType) {
-    var items = type.interfaces.where(tester).toList();
+    var tests = type.interfaces.map((type) => _typeTest(type, tester));
+    var interface = _firstNonNull(tests);
 
-    if (items.length > 1) {
-      throw 'weird - more than 1 interface matches the type test - $items';
-    }
-
-    if (items.length == 1) {
-      return items.single;
-    }
+    if (interface != null) return interface;
 
     if (type.superclass != null) {
       return _typeTest(type.superclass, tester);
@@ -294,6 +289,9 @@ ParameterizedType _typeTest(
   }
   return null;
 }
+
+/*=T*/ _firstNonNull/*<T>*/(Iterable/*<T>*/ values) =>
+    values.firstWhere((value) => value != null, orElse: () => null);
 
 bool _isDartIterable(DartType type) {
   return type.element.library != null &&

--- a/lib/generators/json_serializable_generator.dart
+++ b/lib/generators/json_serializable_generator.dart
@@ -279,9 +279,9 @@ ParameterizedType _typeTest(
 
   if (type is InterfaceType) {
     var tests = type.interfaces.map((type) => _typeTest(type, tester));
-    var interface = _firstNonNull(tests);
+    var match = _firstNonNull(tests);
 
-    if (interface != null) return interface;
+    if (match != null) return match;
 
     if (type.superclass != null) {
       return _typeTest(type.superclass, tester);


### PR DESCRIPTION
The `interfaces` getter does not behave as expected. See
https://github.com/dart-lang/sdk/issues/27947

This code was safe before since List happened to explicitly have
`implements Iterable`, but now that there is an
`EfficientLengthIterable` interface in between it isn't working.

Recursively check interfaces the same way we recursively check the
superclass. This now ignores the edge case where multiple interfaces
matched the tester and will return the first match.