### PR TITLE
Extract matchTypes from matchAnnotation.

### DIFF
--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -214,6 +214,8 @@ DeclarationMirror _getDeclarationMirrorFromType(InterfaceType type) {
   return libMirror.declarations[typeNameSymbol];
 }
 
+/// Checks whether the constant type of [annotation] is equivalent to
+/// [annotationType].
 bool matchAnnotation(Type annotationType, ElementAnnotation annotation) {
   var annotationValueType = annotation.constantValue?.type;
   if (annotationValueType == null) {
@@ -224,6 +226,10 @@ bool matchAnnotation(Type annotationType, ElementAnnotation annotation) {
   return matchTypes(annotationType, annotationValueType);
 }
 
+/// Checks whether [annotationValueType] is equivalent to [annotationType].
+///
+/// Currently, this uses mirrors to compare the name and library uri of the two
+/// types.
 bool matchTypes(Type annotationType, ParameterizedType annotationValueType) {
   var classMirror = reflectClass(annotationType);
   var classMirrorSymbol = classMirror.simpleName;

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -215,14 +215,18 @@ DeclarationMirror _getDeclarationMirrorFromType(InterfaceType type) {
 }
 
 bool matchAnnotation(Type annotationType, ElementAnnotation annotation) {
-  var classMirror = reflectClass(annotationType);
-  var classMirrorSymbol = classMirror.simpleName;
-
   var annotationValueType = annotation.constantValue?.type;
   if (annotationValueType == null) {
     throw new ArgumentError.value(annotation, 'annotation',
         'Could not determine type of annotation. Are you missing a dependency?');
   }
+  
+  return matchTypes(annotationType, annotationValueType);
+}
+
+bool matchTypes(Type annotationType, ParameterizedType annotationValueType) {
+  var classMirror = reflectClass(annotationType);
+  var classMirrorSymbol = classMirror.simpleName;
 
   var annTypeName = annotationValueType.name;
   var annotationTypeSymbol = new Symbol(annTypeName);


### PR DESCRIPTION
Extract matchTypes from matchAnnotation so that it can be used in cases where the type comes from a different source (like a DartObject instance).