### PR TITLE
Make use of analyzer's new resolutionMap interface.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 String friendlyNameForElement(Element element) {
@@ -50,9 +51,10 @@ Iterable<Element> getElementsFromLibraryElement(LibraryElement unit) sync* {
 
 Iterable<Element> _getElements(CompilationUnitMember member) {
   if (member is TopLevelVariableDeclaration) {
-    return member.variables.variables.map((v) => v.element);
+    return member.variables.variables
+        .map(resolutionMap.elementDeclaredByVariableDeclaration);
   }
-  var element = member.element;
+  var element = resolutionMap.elementDeclaredByDeclaration(member);
 
   if (element == null) {
     print([member, member.runtimeType, member.element]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/source_gen
 environment:
   sdk: '>=1.12.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.28.0 <0.30.0'
+  analyzer: ^0.29.2
   build: '>=0.2.1 <0.7.0'
   dart_style: '>=0.1.7 <0.3.0'
   path: ^1.3.2


### PR DESCRIPTION
The getters in the analyzer's AST data structures will soon be changed to less specific types, so we need to use the new interface in order to avoid warnings.