### PR TITLE
Smooth degradataion for non-library assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.3+1
+
+* Don't throw when running against a non-library asset and getting no
+  LibraryElement
+
 ## 0.5.3
 
 * Add matchTypes method. As with anything imported from /src/ this is

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -31,6 +31,7 @@ class GeneratorBuilder extends Builder {
     var id = buildStep.input.id;
     var resolver = await buildStep.resolve(id, resolveAllConstants: false);
     var lib = resolver.getLibrary(id);
+    if (lib == null) return;
     await _generateForLibrary(lib, buildStep);
     resolver.release();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.5.3
+version: 0.5.3+1
 author: Dart Team <misc@dartlang.org>
 description: Automatic sourcecode generation for Dart
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
If we can't get a LibraryElement for a primary input it should not have
any output. Return early rather than throw later.