### PR TITLE
Add more context about dartfmt failures

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -78,10 +78,13 @@ class GeneratorBuilder extends Builder {
       genPartContent = formatter.format(genPartContent);
     } catch (e, stack) {
       buildStep.logger.severe(
-          """Error formatting the generated source code.
-This may indicate an issue in the generated code or in the formatter.
-Please check the generated code and file an issue on source_gen
-if approppriate.""",
+          ''
+          'Error formatting generated source code for ${library.identifier} '
+          'which was output to ${_generatedFile(buildStep.inputId).path}.\n'
+          'This may indicate an issue in the generated code or in the formatter.'
+          '\n'
+          'Please check the generated code and file an issue on source_gen if '
+          'appropriate.',
           e,
           stack);
     }

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -78,13 +78,10 @@ class GeneratorBuilder extends Builder {
       genPartContent = formatter.format(genPartContent);
     } catch (e, stack) {
       buildStep.logger.severe(
-          ''
-          'Error formatting generated source code for ${library.identifier} '
-          'which was output to ${_generatedFile(buildStep.inputId).path}.\n'
-          'This may indicate an issue in the generated code or in the formatter.'
-          '\n'
-          'Please check the generated code and file an issue on source_gen if '
-          'appropriate.',
+          '''Error formatting generated source code for ${library.identifier}
+which was output to ${_generatedFile(buildStep.inputId).path}.\n
+This may indicate an issue in the generated code or in the formatter.\n
+Please check the generated code and file an issue on source_gen if appropriate.''',
           e,
           stack);
     }


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_gen/issues/130.

I validated internally this produces a nicer error message, such as:

```
[SEVERE]: Error formatting the generated source code for <REDACTED>|lib/focus_trap.dart which was output to lib/focus_trap.template.dart.
This may indicate an issue in the generated code or in the formatter.
Please check the generated code and file an issue on source_gen if appropriate.
Could not format because the source could not be parsed:

<REDACTED>
```