### PR TITLE
Reflow and format help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4+1
+
+* Give more information when `dartfmt` fails.
+
 ## 0.5.4
 
 * Update to latest `build`, `build_runner`, and `build_test` releases.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -78,10 +78,12 @@ class GeneratorBuilder extends Builder {
       genPartContent = formatter.format(genPartContent);
     } catch (e, stack) {
       buildStep.logger.severe(
-          '''Error formatting generated source code for ${library.identifier}
-which was output to ${_generatedFile(buildStep.inputId).path}.\n
-This may indicate an issue in the generated code or in the formatter.\n
-Please check the generated code and file an issue on source_gen if appropriate.''',
+          'Error formatting generated source code for ${library.identifier}'
+          'which was output to ${_generatedFile(buildStep.inputId).path}.\n'
+          'This may indicate an issue in the generated code or in the '
+          'formatter.\n'
+          'Please check the generated code and file an issue on source_gen if '
+          'appropriate.',
           e,
           stack);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.5.4
+version: 0.5.4+1
 author: Dart Team <misc@dartlang.org>
 description: Automatic sourcecode generation for Dart
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
Use concatenated `''` rather than `'''` so that we can break lines
separately in the source from where we want them broken in the output