### PR TITLE
Refer to library by URL.

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -55,6 +55,7 @@ class GeneratorBuilder extends Builder {
     var contentBuffer = new StringBuffer();
 
     if (!isStandalone) {
+      contentBuffer.writeln('// ignore: non_identifier_library_name');
       contentBuffer.writeln("part of '${library.definingCompilationUnit.displayName}';");
       contentBuffer.writeln();
     }

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -55,7 +55,7 @@ class GeneratorBuilder extends Builder {
     var contentBuffer = new StringBuffer();
 
     if (!isStandalone) {
-      contentBuffer.writeln('part of ${library.name};');
+      contentBuffer.writeln("part of '${library.definingCompilationUnit.displayName}';");
       contentBuffer.writeln();
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Automatic sourcecode generation for Dart
 homepage: https://github.com/dart-lang/source_gen
 environment:
-  sdk: '>=1.12.0 <2.0.0'
+  sdk: '>=1.23.0-dev.11.0 <2.0.0'
 dependencies:
   analyzer: ^0.29.2
   build: ^0.7.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   analyzer: ^0.29.2
   build: ^0.7.1
-  dart_style: '>=0.1.7 <2.0.0'
+  dart_style: ^1.0.0
   path: ^1.3.2
 dev_dependencies:
   build_runner: ^0.3.0

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -153,13 +153,15 @@ class MyGoodError { }
 ''';
 
 const _testLibPartContent = r'''
-part of test_lib;
+// ignore: non_identifier_library_name
+part of 'test_lib.dart';
 final int bar = 42;
 class Customer { }
 ''';
 
 const _testGenPartContent = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore: non_identifier_library_name
 part of 'test_lib.dart';
 
 
@@ -181,6 +183,7 @@ part of 'test_lib.dart';
 const _testGenPartContentForLibrary =
     r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore: non_identifier_library_name
 part of 'test_lib.dart';
 
 
@@ -212,6 +215,7 @@ const _testGenStandaloneContent = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 const _testGenPartContentForClassesAndLibrary =
     r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore: non_identifier_library_name
 part of 'test_lib.dart';
 
 
@@ -239,6 +243,7 @@ part of 'test_lib.dart';
 
 const _testGenPartContentError = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore: non_identifier_library_name
 part of 'test_lib.dart';
 
 

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -160,7 +160,8 @@ class Customer { }
 
 const _testGenPartContent = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of test_lib;
+part of 'test_lib.dart';
+
 
 // **************************************************************************
 // Generator: CommentGenerator
@@ -180,7 +181,8 @@ part of test_lib;
 const _testGenPartContentForLibrary =
     r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of test_lib;
+part of 'test_lib.dart';
+
 
 // **************************************************************************
 // Generator: CommentGenerator
@@ -210,7 +212,8 @@ const _testGenStandaloneContent = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 const _testGenPartContentForClassesAndLibrary =
     r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of test_lib;
+part of 'test_lib.dart';
+
 
 // **************************************************************************
 // Generator: CommentGenerator
@@ -236,7 +239,8 @@ part of test_lib;
 
 const _testGenPartContentError = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of test_lib;
+part of 'test_lib.dart';
+
 
 // **************************************************************************
 // Generator: CommentGenerator
@@ -246,6 +250,7 @@ part of test_lib;
 // Error: Invalid argument (element): We don't support class names with the word 'Error'.
 //        Try renaming the class.: Instance of 'ClassElementImpl'
 
+
 // **************************************************************************
 // Generator: CommentGenerator
 // Target: class MyGoodError
@@ -253,6 +258,7 @@ part of test_lib;
 
 // Error: Don't use classes with the word 'Error' in the name
 // TODO: Rename MyGoodError to something else.
+
 
 // **************************************************************************
 // Generator: CommentGenerator


### PR DESCRIPTION
This will let people get rid of 'library' statements.

Really looking forward to this change -- any plans for when we can make it? Do we need to wait for 1.23 to be in the stable channel?

I checked built_value's end to end tests with 1.23.0-dev.11.0 and it works fine. The analyzed currently complains, but we don't necessarily need to wait for that -- we can silence it with "// ignore: non_identifier_library_name".

Thanks!