### PR TITLE
Less verbose error for analysis error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dart:
   - stable
   - 1.22.1
   - 1.21.1
-  - 1.20.1
-  - 1.19.1
 cache:
   directories:
     - $HOME/.pub-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.5
+
+* Less verbose errors when analyzer fails to resolve the input.
+
 ## 0.5.4+3
 
 * Support the latest release of `pkg/dart_style`.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -100,8 +100,8 @@ class GeneratorBuilder extends Builder {
 Stream<GeneratedOutput> _generate(LibraryElement unit,
     List<Generator> generators, BuildStep buildStep) async* {
   var elements = safeIterate(getElementsFromLibraryElement(unit), (e, [_]) {
-    log.severe('Failed to resolve ${buildStep.inputId}.');
     log.fine('Resolve error details:\n$e');
+    log.severe('Failed to resolve ${buildStep.inputId}.');
   });
   for (var element in elements) {
     yield* _processUnitMember(element, generators, buildStep);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/exception/exception.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/src/dart_formatter.dart';
 
@@ -98,7 +99,11 @@ class GeneratorBuilder extends Builder {
 
 Stream<GeneratedOutput> _generate(LibraryElement unit,
     List<Generator> generators, BuildStep buildStep) async* {
-  for (var element in getElementsFromLibraryElement(unit)) {
+  var elements = safeIterate(getElementsFromLibraryElement(unit), (e, [_]) {
+    log.severe('Failed to resolve ${buildStep.inputId}.');
+    log.fine('Resolve error details:\n$e');
+  });
+  for (var element in elements) {
     yield* _processUnitMember(element, generators, buildStep);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -49,6 +49,20 @@ Iterable<Element> getElementsFromLibraryElement(LibraryElement unit) sync* {
   }
 }
 
+/// Returns an Iterable that will not throw any exceptions while iterating.
+///
+/// If an exception occurs while iterating [iterable] the return value will
+/// finish and [onError] will be called.
+Iterable<T> safeIterate<T>(Iterable<T> iterable, void onError(e, st)) sync* {
+  try {
+    for (var e in iterable) {
+      yield e;
+    }
+  } catch (e, st) {
+    onError(e, st);
+  }
+}
+
 Iterable<Element> _getElements(CompilationUnitMember member) {
   if (member is TopLevelVariableDeclaration) {
     return member.variables.variables

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: source_gen
-version: 0.5.4+3
+version: 0.5.5
 author: Dart Team <misc@dartlang.org>
 description: Automatic sourcecode generation for Dart
 homepage: https://github.com/dart-lang/source_gen
 environment:
-  sdk: '>=1.12.0 <2.0.0'
+  sdk: '>=1.22.0 <2.0.0'
 dependencies:
   analyzer: ^0.29.2
   build: ^0.7.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Automatic sourcecode generation for Dart
 homepage: https://github.com/dart-lang/source_gen
 environment:
-  sdk: '>=1.22.0 <2.0.0'
+  sdk: '>=1.21.1 <2.0.0'
 dependencies:
   analyzer: ^0.29.2
   build: ^0.7.1


### PR DESCRIPTION
The AnalysisException thrown during initial iterating over elements can
be very noisy. Stack traces are included in the `toString()` and it's
detail that most users won't care about.

- Add a safeIterate utility method which allows catching the exceptions
  specifically thrown by the elements iterable and not by the Builder
- Simplify to a message about failing to resolve the input. Include the
  extra details in a log.fine