### PR TITLE
Add TypeChecker class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
 ## 0.5.9
 
 * Update the minimum Dart SDK to `1.22.1`.
+* Added `TypeChecker`, a high-level API for performing static type checks:
+
+```dart
+import 'package:analyzer/dart/element/type.dart';
+import 'package:source_gen/source_gen.dart';
+
+void checkType(DartType dartType) {
+  // Checks compared to runtime type `SomeClass`.
+  print(const TypeChecker.forRuntime(SomeClass).isExactlyType(dartType));
+  
+  // Checks compared to a known Url/Symbol:
+  const TypeChecker.forUrl('package:foo/foo.dart#SomeClass');
+  
+  // Checks compared to another resolved `DartType`:
+  const TypeChecker.forStatic(anotherDartType);
+}
+```
 
 ## 0.5.8
 
 * Add `formatOutput` optional parameter to the `GeneratorBuilder` constructor.
-  This is a lamda of the form `String formatOutput(String originalCode)` which
+  This is a lambda of the form `String formatOutput(String originalCode)` which
   allows you do do custom formatting.
 
 ## 0.5.7

--- a/lib/generators/json_serializable_generator.dart
+++ b/lib/generators/json_serializable_generator.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/generated/utilities_dart.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:source_gen/src/annotation.dart';
 import 'package:source_gen/src/json_serializable/type_helper.dart';
 import 'package:source_gen/src/utils.dart';
 
@@ -278,11 +277,10 @@ class JsonSerializableGenerator
 /// [fieldName] is used, unless [field] is annotated with [JsonKey], in which
 /// case [JsonKey.jsonName] is used.
 String _fieldToJsonMapKey(String fieldName, FieldElement field) {
-  var metadata = field.metadata;
-  var jsonKey = metadata.firstWhere((m) => matchAnnotation(JsonKey, m),
-      orElse: () => null);
+  const $JsonKey = const TypeChecker.fromRuntime(JsonKey);
+  var jsonKey = $JsonKey.annotationOf(field);
   if (jsonKey != null) {
-    var jsonName = jsonKey.constantValue.getField('jsonName').toStringValue();
+    var jsonName = jsonKey.getField('jsonName').toStringValue();
     return jsonName;
   }
   return fieldName;

--- a/lib/generators/json_serializable_generator.dart
+++ b/lib/generators/json_serializable_generator.dart
@@ -278,7 +278,7 @@ class JsonSerializableGenerator
 /// case [JsonKey.jsonName] is used.
 String _fieldToJsonMapKey(String fieldName, FieldElement field) {
   const $JsonKey = const TypeChecker.fromRuntime(JsonKey);
-  var jsonKey = $JsonKey.annotationOf(field);
+  var jsonKey = $JsonKey.firstAnnotationOf(field);
   if (jsonKey != null) {
     var jsonName = jsonKey.getField('jsonName').toStringValue();
     return jsonName;

--- a/lib/generators/json_serializable_generator.dart
+++ b/lib/generators/json_serializable_generator.dart
@@ -314,11 +314,7 @@ T _firstNotNull<T>(Iterable<T> values) =>
     values.firstWhere((value) => value != null, orElse: () => null);
 
 bool _isDartIterable(DartType type) =>
-    type.element.library != null &&
-    type.element.library.isDartCore &&
-    type.name == 'Iterable';
+    const TypeChecker.fromUrl('dart:core#Iterable').isExactlyType(type);
 
 bool _isDartList(DartType type) =>
-    type.element.library != null &&
-    type.element.library.isDartCore &&
-    type.name == 'List';
+    const TypeChecker.fromUrl('dart:core#List').isExactlyType(type);

--- a/lib/source_gen.dart
+++ b/lib/source_gen.dart
@@ -3,3 +3,4 @@ library source_gen;
 export 'src/builder.dart';
 export 'src/generator.dart';
 export 'src/generator_for_annotation.dart';
+export 'src/type_checker.dart' show TypeChecker;

--- a/lib/src/type_checker.dart
+++ b/lib/src/type_checker.dart
@@ -113,6 +113,9 @@ class _MirrorTypeChecker extends TypeChecker {
 // Checks a runtime type against an Uri and Symbol.
 class _UriTypeChecker extends TypeChecker {
   static String _urlOf(Element element) {
+    if (element.kind == ElementKind.DYNAMIC) {
+      return 'dart:core#dynamic';
+    }
     var sourceUri = element.source.uri;
     switch (sourceUri.scheme) {
       case 'dart':

--- a/lib/src/type_checker.dart
+++ b/lib/src/type_checker.dart
@@ -1,0 +1,135 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:mirrors';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+/// An abstraction around doing static type checking at compile/build time.
+abstract class TypeChecker {
+  const TypeChecker._();
+
+  /// Create a new [TypeChecker] backed by a runtime [type].
+  ///
+  /// This implementation uses `dart:mirrors` (runtime reflection).
+  const factory TypeChecker.fromRuntime(Type type) = _MirrorTypeChecker;
+
+  /// Create a new [TypeChecker] backed by a static [type].
+  const factory TypeChecker.fromStatic(DartType type) = _LibraryTypeChecker;
+
+  /// Create a new [TypeChecker] backed by a library [url].
+  ///
+  /// Example of referring to a `LinkedHashMap` from `dart:collection`:
+  /// ```dart
+  /// const linkedHashMap = const TypeChecker.fromUrl(
+  ///   'dart:collection#LinkedHashMap',
+  /// );
+  /// ```
+  const factory TypeChecker.fromUrl(dynamic url) = _UriTypeChecker;
+
+  /// Returns `true` if representing the exact same class as [element].
+  bool isExactly(Element element);
+
+  /// Returns `true` if representing the exact same type as [staticType].
+  bool isExactlyType(DartType staticType) => isExactly(staticType.element);
+
+  /// Returns `true` if representing a super class of [element].
+  bool isSuperOf(Element element) =>
+      isExactly(element) ||
+      element is ClassElement && element.allSupertypes.any(isExactlyType);
+
+  /// Returns `true` if representing a super type of [staticType].
+  bool isSuperType(DartType staticType) => isSuperOf(staticType.element);
+}
+
+// Checks a static type against another static type;
+class _LibraryTypeChecker extends TypeChecker {
+  final DartType _type;
+
+  const _LibraryTypeChecker(this._type) : super._();
+
+  @override
+  bool isExactly(Element element) =>
+      element is ClassElement && element.type == _type;
+
+  @override
+  bool isSuperOf(Element element) =>
+      isExactly(element) ||
+      element is ClassElement &&
+          element.allSupertypes.any((t) => t.element == _type.element);
+
+  @override
+  String toString() => '${_UriTypeChecker._urlOf(_type.element)}';
+}
+
+// Checks a runtime type against a static type.
+class _MirrorTypeChecker extends TypeChecker {
+  static Uri _uriOf(ClassMirror mirror) {
+    final sourceUri = (mirror.owner as LibraryMirror).uri;
+    switch (sourceUri.scheme) {
+      case 'dart':
+      case 'package':
+        return sourceUri.replace(
+          fragment: MirrorSystem.getName(mirror.simpleName),
+        );
+      default:
+        throw new StateError('Cannot resolve "$sourceUri".');
+    }
+  }
+
+  // Precomputed type checker for types that already have been used.
+  static final _cache = new Expando<TypeChecker>();
+
+  final Type _type;
+
+  const _MirrorTypeChecker(this._type) : super._();
+
+  TypeChecker get _computed =>
+      _cache[this] ??= new TypeChecker.fromUrl(_uriOf(reflectClass(_type)));
+
+  @override
+  bool isExactly(Element element) => _computed.isExactly(element);
+
+  @override
+  String toString() => _computed.toString();
+}
+
+// Checks a runtime type against an Uri and Symbol.
+class _UriTypeChecker extends TypeChecker {
+  static String _urlOf(Element element) {
+    var sourceUri = element.source.uri;
+    switch (sourceUri.scheme) {
+      case 'dart':
+        if (sourceUri.pathSegments.isNotEmpty) {
+          final path = sourceUri.pathSegments.first;
+          sourceUri = sourceUri.replace(pathSegments: [path]);
+        }
+        break;
+      case 'package':
+        break;
+      default:
+        throw new StateError('Cannot resolve "$sourceUri".');
+    }
+    return sourceUri.replace(fragment: element.name).toString();
+  }
+
+  final String _url;
+
+  const _UriTypeChecker(dynamic url)
+      : _url = '$url',
+        super._();
+
+  @override
+  bool operator ==(Object o) => o is _UriTypeChecker && o._url == _url;
+
+  @override
+  int get hashCode => _url.hashCode;
+
+  @override
+  bool isExactly(Element element) => _urlOf(element) == _url;
+
+  @override
+  String toString() => '$_url';
+}

--- a/lib/src/type_checker.dart
+++ b/lib/src/type_checker.dart
@@ -4,6 +4,7 @@
 
 import 'dart:mirrors';
 
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
@@ -28,6 +29,19 @@ abstract class TypeChecker {
   /// );
   /// ```
   const factory TypeChecker.fromUrl(dynamic url) = _UriTypeChecker;
+
+  /// Returns the first constant annotating [element] that is this type.
+  ///
+  /// Otherwise returns `null`.
+  DartObject annotationOf(Element element) {
+    for (final metadata in element.metadata) {
+      final constant = metadata.computeConstantValue();
+      if (isExactlyType(constant.type)) {
+        return constant;
+      }
+    }
+    return null;
+  }
 
   /// Returns `true` if representing the exact same class as [element].
   bool isExactly(Element element);

--- a/lib/src/type_checker.dart
+++ b/lib/src/type_checker.dart
@@ -122,8 +122,8 @@ class _LibraryTypeChecker extends TypeChecker {
 // Checks a runtime type against a static type.
 class _MirrorTypeChecker extends TypeChecker {
   static Uri _uriOf(ClassMirror mirror) =>
-      _normalizeUrl((mirror.owner as LibraryMirror).uri).replace(
-          fragment: MirrorSystem.getName(mirror.simpleName));
+      _normalizeUrl((mirror.owner as LibraryMirror).uri)
+          .replace(fragment: MirrorSystem.getName(mirror.simpleName));
 
   // Precomputed type checker for types that already have been used.
   static final _cache = new Expando<TypeChecker>();

--- a/test/type_checker_test.dart
+++ b/test/type_checker_test.dart
@@ -37,7 +37,7 @@ void main() {
     group('(Map)', () {
       test('should equal dart:core#Map', () {
         expect(checkMap().isExactlyType(staticMap), isTrue,
-            reason: '$checkMap != $staticMap');
+            reason: '${checkMap()} != $staticMap');
       });
 
       test('should not be a super type of dart:core#Map', () {
@@ -46,7 +46,7 @@ void main() {
 
       test('should not equal dart:core#HashMap', () {
         expect(checkMap().isExactlyType(staticHashMap), isFalse,
-            reason: '$checkMap == $staticHashMapChecker');
+            reason: '${checkMap()} == $staticHashMapChecker');
       });
 
       test('should be a super type of dart:collection#HashMap', () {
@@ -57,7 +57,7 @@ void main() {
     group('(HashMap)', () {
       test('should equal dart:collection#HashMap', () {
         expect(checkHashMap().isExactlyType(staticHashMap), isTrue,
-            reason: '$checkHashMap != $staticHashMapChecker');
+            reason: '${checkHashMap()} != $staticHashMapChecker');
       });
 
       test('should not be a super type of dart:core#Map', () {

--- a/test/type_checker_test.dart
+++ b/test/type_checker_test.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:analyzer/dart/element/type.dart';
+import 'package:build_test/build_test.dart';
+import 'package:meta/meta.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Resolved top-level types from dart:core and dart:collection.
+  DartType staticMap;
+  DartType staticHashMap;
+  TypeChecker staticMapChecker;
+  TypeChecker staticHashMapChecker;
+
+  setUpAll(() async {
+    final resolver = await resolveSource('');
+
+    final core = resolver.getLibraryByName('dart.core');
+    staticMap = core.getType('Map').type;
+    staticMapChecker = new TypeChecker.fromStatic(staticMap);
+
+    final collection = resolver.getLibraryByName('dart.collection');
+    staticHashMap = collection.getType('HashMap').type;
+    staticHashMapChecker = new TypeChecker.fromStatic(staticHashMap);
+  });
+
+  // Run a common set of type comparison checks with various implementations.
+  void commonTests({
+    @required TypeChecker checkMap(),
+    @required TypeChecker checkHashMap(),
+  }) {
+    group('(Map)', () {
+      test('should equal dart:core#Map', () {
+        expect(
+          checkMap().isExactlyType(staticMap),
+          isTrue,
+          reason: '$checkMap != $staticMap',
+        );
+      });
+
+      test('should not be a super type of dart:core#Map', () {
+        expect(checkMap().isSuperType(staticMap), isTrue);
+      });
+
+      test('should not equal dart:core#HashMap', () {
+        expect(
+          checkMap().isExactlyType(staticHashMap),
+          isFalse,
+          reason: '$checkMap == $staticHashMapChecker',
+        );
+      });
+
+      test('should be a super type of dart:collection#HashMap', () {
+        expect(checkMap().isSuperType(staticHashMap), isTrue);
+      });
+    });
+
+    group('(HashMap)', () {
+      test('should equal dart:collection#HashMap', () {
+        expect(
+          checkHashMap().isExactlyType(staticHashMap),
+          isTrue,
+          reason: '$checkHashMap != $staticHashMapChecker',
+        );
+      });
+
+      test('should not be a super type of dart:core#Map', () {
+        expect(checkHashMap().isSuperType(staticMap), isFalse);
+      });
+    });
+  }
+
+  group('TypeChecker.forRuntime', () {
+    commonTests(
+      checkMap: () => const TypeChecker.fromRuntime(Map),
+      checkHashMap: () => const TypeChecker.fromRuntime(HashMap),
+    );
+  });
+
+  group('TypeChecker.forStatic', () {
+    commonTests(
+      checkMap: () => staticMapChecker,
+      checkHashMap: () => staticHashMapChecker,
+    );
+  });
+
+  group('TypeChecker.fromUrl', () {
+    commonTests(
+      checkMap: () => const TypeChecker.fromUrl('dart:core#Map'),
+      checkHashMap: () => const TypeChecker.fromUrl('dart:collection#HashMap'),
+    );
+  });
+}

--- a/test/type_checker_test.dart
+++ b/test/type_checker_test.dart
@@ -36,63 +36,52 @@ void main() {
   }) {
     group('(Map)', () {
       test('should equal dart:core#Map', () {
-        expect(
-          checkMap().isExactlyType(staticMap),
-          isTrue,
-          reason: '$checkMap != $staticMap',
-        );
+        expect(checkMap().isExactlyType(staticMap), isTrue,
+            reason: '$checkMap != $staticMap');
       });
 
       test('should not be a super type of dart:core#Map', () {
-        expect(checkMap().isSuperType(staticMap), isTrue);
+        expect(checkMap().isSuperTypeOf(staticMap), isFalse);
       });
 
       test('should not equal dart:core#HashMap', () {
-        expect(
-          checkMap().isExactlyType(staticHashMap),
-          isFalse,
-          reason: '$checkMap == $staticHashMapChecker',
-        );
+        expect(checkMap().isExactlyType(staticHashMap), isFalse,
+            reason: '$checkMap == $staticHashMapChecker');
       });
 
       test('should be a super type of dart:collection#HashMap', () {
-        expect(checkMap().isSuperType(staticHashMap), isTrue);
+        expect(checkMap().isSuperTypeOf(staticHashMap), isTrue);
       });
     });
 
     group('(HashMap)', () {
       test('should equal dart:collection#HashMap', () {
-        expect(
-          checkHashMap().isExactlyType(staticHashMap),
-          isTrue,
-          reason: '$checkHashMap != $staticHashMapChecker',
-        );
+        expect(checkHashMap().isExactlyType(staticHashMap), isTrue,
+            reason: '$checkHashMap != $staticHashMapChecker');
       });
 
       test('should not be a super type of dart:core#Map', () {
-        expect(checkHashMap().isSuperType(staticMap), isFalse);
+        expect(checkHashMap().isSuperTypeOf(staticMap), isFalse);
       });
     });
   }
 
   group('TypeChecker.forRuntime', () {
     commonTests(
-      checkMap: () => const TypeChecker.fromRuntime(Map),
-      checkHashMap: () => const TypeChecker.fromRuntime(HashMap),
-    );
+        checkMap: () => const TypeChecker.fromRuntime(Map),
+        checkHashMap: () => const TypeChecker.fromRuntime(HashMap));
   });
 
   group('TypeChecker.forStatic', () {
     commonTests(
-      checkMap: () => staticMapChecker,
-      checkHashMap: () => staticHashMapChecker,
-    );
+        checkMap: () => staticMapChecker,
+        checkHashMap: () => staticHashMapChecker);
   });
 
   group('TypeChecker.fromUrl', () {
     commonTests(
-      checkMap: () => const TypeChecker.fromUrl('dart:core#Map'),
-      checkHashMap: () => const TypeChecker.fromUrl('dart:collection#HashMap'),
-    );
+        checkMap: () => const TypeChecker.fromUrl('dart:core#Map'),
+        checkHashMap: () =>
+            const TypeChecker.fromUrl('dart:collection#HashMap'));
   });
 }


### PR DESCRIPTION
This will be nice to have versus stuffed into the AngularDart compiler, and it doesn't feel "right" going into a library like `build`, which I think benefits from having a very small interface and low-threshold for changes.

Advantages of this approach
* Adds an "approved" (not `/lib/src/annotations.dart') way of performing checks.
* Has two backing implementations not based on `dart:mirrors` (for long-term safety).
* Easy re-usable setup for complex compilers like `inject` or `angular`.

See `type_checker_test.dart` for some functional tests.

Closes https://github.com/dart-lang/source_gen/issues/136.