### PR TITLE
Incremental enhancements to README and dartdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,56 @@
-[![Build Status](https://travis-ci.org/dart-lang/source_gen.svg?branch=master)](https://travis-ci.org/dart-lang/source_gen)
+# source_gen
 
-`source_gen` provides:
+<p align="center">
+  <a href="https://travis-ci.org/dart-lang/source_gen">
+    <img src="https://travis-ci.org/dart-lang/source_gen.svg?branch=master" alt="Build Status" />
+  </a>
+  <a href="https://pub.dartlang.org/packages/source_gen">
+    <img src="https://img.shields.io/pub/v/twitch.svg" alt="Pub Package Version" />
+  </a>
+  <a href="https://gitter.im/dart-lang/source_gen">
+    <img src="https://badges.gitter.im/dart-lang/source_gen.svg" alt="Join the chat on Gitter" />
+  </a>
+</p>
+
+## Overview
+
+`source_gen` provides utilities for automated source code generation for Dart:
 
 * A **tool** for generating code that is part of your Dart project.
 * A **framework** for creating and using multiple code generators in a single
   project.
 * A **convention** for human and tool generated Dart code to coexist with clean
   separation.
+
+It's main purpose is to expose a developer-friendly API on top of lower-level
+packages like the [analyzer](https://pub.dartlang.org/packages/analyzer) or
+[build][]. You don't _have_ to use `source_gen` in order to generate source code
+- we also expose a set of library APIs that might be useful in your generators.
+
+## Quick Start Guide
+
+Because `source_gen` is a package, not an executable, it should be included as
+a dependency in your project. If you are creating a generator for others to use
+(for example, a JSON serialization generator) or a library that builds on top
+of `source_gen` include it in your [pubspec `dependencies`][pub_deps]:
+
+```yaml
+dependencies:
+  source_gen:
+```
+
+If you're only using `source_gen` in your own project to generate code, and
+then you publish that code (generated code included), then you can simply add
+as a `dev_dependency`:
+
+```yaml
+dev_dependencies:
+  source_gen:
+```
+
+[pub_deps]: https://www.dartlang.org/tools/pub/dependencies
+  
+Once you have `source_gen` setup, you should reference the examples below.
 
 ## Example
 
@@ -69,33 +113,63 @@ Extend the `Generator` class to plug into `source_gen`.
 
 ## Running generators
 
-`source_gen` is based on the `build` package (
-  [pub](https://pub.dartlang.org/packages/build),
-  [GitHub](https://github.com/dart-lang/build)).
+`source_gen` is based on the [`build`][build] package.
 
 See `build.dart` and `watch.dart` in the `tool` directory. Both reference
 `tool/phases.dart`, which contains information mapping `source_gen` generators
 to target files.
 
-## source_gen vs Dart Transformers
-[Dart Transformers][] are often used to create and modify code and assets as part
+## FAQ
+
+### What is the difference between `source_gen` and [`build`][build]?
+
+Build is a platform-agnostic framework for Dart asset or code generation that
+is pluggable into multiple build systems including
+[barback (pub/dart transformers)][build_barback], [bazel][bazel_codegen], and
+standalone tools like [build_runner][]. You could also build your own.
+
+Meanwhile, `source_gen` provides an API and tooling that is easily usable on
+top of `build` to make common tasks easier and more developer friendly. For
+example the [`GeneratorBuilder`][api:GeneratorBuilder] class wraps one or
+more [`Generator`][api:Generator] instances to make a [`Builder`][api:Builder].
+
+### What is the difference between `source_gen` and transformers?
+
+[Dart transformers][] are often used to create and modify code and assets as part
 of a Dart project.
 
 Transformers allow modification of existing code and encapsulates changes by
 having developers use `pub` commands – `run`, `serve`, and `build`.
+Unfortunately the API exposed by transformers hinder fast incremental builds,
+output caching, and predictability, so we introduced _builders_ as part of
+[`package:build`][build].
 
-`source_gen` provides a different model. Code is generated and updated
-as part of a project. It is designed to create *part* files that augment
-developer maintained Dart libraries.
+Builders and `source_gen` provide for a different model: outputs _must_ be
+declared ahead of time and code is generated and updated as part of a project.
+It is designed to create *part* _or_ standalone files that augment developer
+maintained Dart libraries. For example [AngularDart][angular2] uses `build` and
+`source_gen` to "compile" HTML and annotation metadata into plain `.dart` code.
 
-Generated code **MAY** be checked in as part of our project source,
-although the decision may vary depending on project needs.
+Unlike _transformers_, generated code **MAY** be checked in as part of your
+project source, although the decision may vary depending on project needs.
 
 Generated code **SHOULD** be included when publishing a project as a *pub
 package*. The fact that `source_gen` is used in a package is an *implementation
 detail*.
 
-[Dart Transformers]: https://www.dartlang.org/tools/pub/assets-and-transformers.html
+<!-- Packages -->
+[angular2]: https://pub.dartlang.org/packages/angular2
+[bazel_codegen]: https://pub.dartlang.org/packages/_bazel_codegen
+[build]: https://pub.dartlang.org/packages/build
+[build_barback]: https://pub.dartlang.org/packages/build_barback
+[build_runner]: https://pub.dartlang.org/packages/build_runner
+
+<!-- Dartdoc -->
+[api:Builder]: https://www.dartdocs.org/documentation/build/latest/builder/Builder-class.html
+[api:Generator]: https://www.dartdocs.org/documentation/source_gen/latest/builder/Generator-class.html
+[api:GeneratorBuilder]: https://www.dartdocs.org/documentation/source_gen/latest/builder/GeneratorBuilder-class.html
+
+[Dart transformers]: https://www.dartlang.org/tools/pub/assets-and-transformers.html
 [example code]: https://github.com/dart-lang/source_gen/tree/master/example
 [Trivial example]: https://github.com/dart-lang/source_gen/blob/master/test/src/comment_generator.dart
 [Included generators]: https://github.com/dart-lang/source_gen/tree/master/lib/generators

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 
 It's main purpose is to expose a developer-friendly API on top of lower-level
 packages like the [analyzer](https://pub.dartlang.org/packages/analyzer) or
-[build][]. You don't _have_ to use `source_gen` in order to generate source code
-- we also expose a set of library APIs that might be useful in your generators.
+[build][]. You don't _have_ to use `source_gen` in order to generate source code;
+we also expose a set of library APIs that might be useful in your generators.
 
 ## Quick Start Guide
 

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -11,24 +11,51 @@ import 'generated_output.dart';
 import 'generator.dart';
 import 'utils.dart';
 
+/// Returns [generatedCode] formatted, usually with something like `dartfmt`.
 typedef String OutputFormatter(String generatedCode);
 
+/// Wraps multiple [Generator]s and exposes them as a [Builder] for tooling.
+///
+/// ```dart
+/// // Creates a new builder that the following two generators.
+/// new GeneratorBuilder([
+///   new JsonSerializableGenerator(),
+///   new JsonLiteralGenerator(),
+/// ]);
+/// ```
 class GeneratorBuilder extends Builder {
+  /// Function that determines how the generated code is formatted.
   final OutputFormatter formatOutput;
+
+  /// What underlying generators are wrapped to form this [Builder].
   final List<Generator> generators;
+
+  /// For a given `.dart` file what extension is used to generate code.
+  ///
+  /// Defaults to `.g.dart`.
   final String generatedExtension;
+
+  /// Whether to emit a standalone (non-`part`) file in this builder.
   final bool isStandalone;
 
+  /// Wrap [generators] to form a [Builder]-compatible API.
   GeneratorBuilder(this.generators,
       {OutputFormatter formatOutput,
       this.generatedExtension: '.g.dart',
       this.isStandalone: false})
       : formatOutput = formatOutput ?? _formatter.format {
-    // TODO: validate that generatedExtension starts with a `.'
-    //       not null, empty, etc
+    if (generatedExtension == null) {
+      throw new ArgumentError.notNull('generatedExtension');
+    }
+    if (generatedExtension.isEmpty ||
+        !generatedExtension.startsWith('.') ||
+        !generatedExtension.endsWith('.dart')) {
+      throw new ArgumentError.value(generatedExtension, 'generatedExtension',
+          'Extension must be in the format of .dart or .*.dart');
+    }
     if (this.isStandalone && this.generators.length > 1) {
       throw new ArgumentError(
-          'Only one generator can be used to generate a standalone file.');
+          'A standalone file can only be generated from a single Generator.');
     }
   }
 

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -9,17 +9,36 @@ import 'dart:async';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 
+/// A simple API surface for emitting Dart source code from existing code.
+///
+/// Clients should _extend_ this class and _override_ [generate]:
+/// ```dart
+/// class MyGenerator extends Generator {
+///   Future<String> generate(Element element, BuildStep buildStep) async {
+///     // Return a string representing the code to emit.
+///   }
+/// }
+/// ```
 abstract class Generator {
   const Generator();
 
+  /// Override to return source code for a given [element].
+  ///
+  /// May return `null` to signify "nothing to generate".
   Future<String> generate(Element element, BuildStep buildStep) => null;
 
   @override
   String toString() => this.runtimeType.toString();
 }
 
+/// May be thrown by generators during [Generator.generate].
 class InvalidGenerationSourceError extends Error {
+  /// What failure occurred.
   final String message;
+
+  /// What could have been changed in the source code to resolve this error.
+  ///
+  /// May be an empty string if unknown.
   final String todo;
 
   InvalidGenerationSourceError(this.message, {String todo})

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: source_gen
 version: 0.5.9-dev
 author: Dart Team <misc@dartlang.org>
-description: Automatic sourcecode generation for Dart
+description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen
 environment:
   sdk: '>=1.22.1 <2.0.0'


### PR DESCRIPTION
Specifically, clarifying the _role_ of this package (since it forked into `build`), what this package _does_ and (does not do), and added API documentation to the most common classes that were sorely lacking.

I also added a gitter chatroom, since there seems to be enough users trying this out to warrant. We can probably re-use this chatroom for the various build packages.

Closes https://github.com/dart-lang/source_gen/issues/135.