### PR TITLE
Patch instantiateAnnotation to support extended annotation classes

### DIFF
--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -151,6 +151,8 @@ dynamic _createFromConstructor(
       // set it as the argument value
 
       var initializer = ctor.constantInitializers.singleWhere((ci) {
+        // Avoid crashing on SuperConstructor
+        if (ci is SuperConstructorInvocation) return false;
         var expression = (ci as ConstructorFieldInitializer).expression;
         if (expression is SimpleIdentifier) {
           return expression.name == paramName;

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -168,7 +168,7 @@ dynamic _createFromConstructor(
           // from the parent class.
 
           // 1. Find parent class
-          
+
 
           // 2. Determine the name of the field this parameter is assigned to on the parent class.
 

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -150,6 +150,14 @@ dynamic _createFromConstructor(
       // field assigned in the object. Then we can take the field value and
       // set it as the argument value
 
+      // If the annotation class's constructor has no initializers and just
+      // forwards to a `super` class constructor, then there is no need
+      // to add a ctor argument name as a field value.
+      //
+      // In this case `singleWhere` would throw a StateError.
+      if (ctor.constantInitializers.length == 1 && ctor.constantInitializers.first is SuperConstructorInvocation)
+        continue;
+
       var initializer = ctor.constantInitializers.singleWhere((ci) {
         // Avoid crashing on SuperConstructor
         if (ci is SuperConstructorInvocation) return false;

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -150,13 +150,15 @@ dynamic _createFromConstructor(
       // field assigned in the object. Then we can take the field value and
       // set it as the argument value
 
-      // If the annotation class's constructor has no initializers and just
-      // forwards to a `super` class constructor, then there is no need
-      // to add a ctor argument name as a field value.
-      //
-      // In this case `singleWhere` would throw a StateError.
-      if (ctor.constantInitializers.length == 1 && ctor.constantInitializers.first is SuperConstructorInvocation)
+      if (ctor.constantInitializers.length == 1
+          && ctor.constantInitializers.first is SuperConstructorInvocation) {
+        // If the annotation class's constructor has no initializers and just
+        // forwards to a `super` class constructor, then there is no need
+        // to add a ctor argument name as a field value.
+        //
+        // In this case `singleWhere` would throw a StateError.
         continue;
+      }
 
       var initializer = ctor.constantInitializers.singleWhere((ci) {
         // Avoid crashing on SuperConstructor

--- a/test/annotation_test.dart
+++ b/test/annotation_test.dart
@@ -78,6 +78,26 @@ void main() {
       expect(instance.aBool, isFalse);
     });
 
+    test('annotated with extended class and forwarded parameters', () {
+      var instance = _getInstantiatedAnnotation(libElement, 'WithChildClassAnnotationAndForwardedParameters');
+      expect(instance is defs.PublicAnnotationClass, isTrue);
+      expect(instance is defs.ExtendedAnnotationClassWithForwardedParameters, isTrue);
+      expect(instance.anInt, 24);
+      expect(instance.aBool, isFalse);
+      expect(instance.aString, 'hello');
+    });
+
+
+    test('annotated with extended class and custom and forwarded parameters', () {
+      var instance = _getInstantiatedAnnotation(libElement, 'WithChildClassAnnotationAndCustomForwardedParameters');
+      expect(instance is defs.PublicAnnotationClass, isTrue);
+      expect(instance is defs.ExtendedAnnotationClassWithCustomAndForwardedParameters, isTrue);
+      expect(instance.customInt, 23);
+      expect(instance.anInt, 24);
+      expect(instance.aBool, isFalse);
+      expect(instance.aString, 'hello');
+    });
+
     test('annotated with class using a non-default ctor', () {
       var instance =
           _getInstantiatedAnnotation(libElement, 'NonDefaultCtorNoParams');

--- a/test/annotation_test.dart
+++ b/test/annotation_test.dart
@@ -71,7 +71,7 @@ void main() {
     });
 
     test('annotated with extended class', () {
-      var instance = _getInstantiatedAnnotation(libElement, 'WithChildClass');
+      var instance = _getInstantiatedAnnotation(libElement, 'WithChildClassAnnotation');
       expect(instance is defs.PublicAnnotationClass, isTrue);
       expect(instance is defs.ExtendedAnnotationClass, isTrue);
       expect(instance.anInt, 0);

--- a/test/annotation_test.dart
+++ b/test/annotation_test.dart
@@ -70,6 +70,14 @@ void main() {
       expect(instance.aBool, isFalse);
     });
 
+    test('annotated with extended class', () {
+      var instance = _getInstantiatedAnnotation(libElement, 'WithChildClass');
+      expect(instance is defs.PublicAnnotationClass, isTrue);
+      expect(instance is defs.ExtendedAnnotationClass, isTrue);
+      expect(instance.anInt, 0);
+      expect(instance.aBool, isFalse);
+    });
+
     test('annotated with class using a non-default ctor', () {
       var instance =
           _getInstantiatedAnnotation(libElement, 'NonDefaultCtorNoParams');

--- a/test/test_files/annotated_classes.dart
+++ b/test/test_files/annotated_classes.dart
@@ -60,3 +60,9 @@ class WithAFieldFromNonDefaultCtor {}
 
 @ExtendedAnnotationClass()
 class WithChildClassAnnotation {}
+
+@ExtendedAnnotationClassWithForwardedParameters(24)
+class WithChildClassAnnotationAndForwardedParameters {}
+
+@ExtendedAnnotationClassWithCustomAndForwardedParameters(23, 24)
+class WithChildClassAnnotationAndCustomForwardedParameters {}

--- a/test/test_files/annotated_classes.dart
+++ b/test/test_files/annotated_classes.dart
@@ -57,3 +57,6 @@ class WithUntypedField {}
 
 @untypedAnnotationWithNonDefaultCtor
 class WithAFieldFromNonDefaultCtor {}
+
+@ExtendedAnnotationClass()
+class WithChildClassAnnotation {}

--- a/test/test_files/annotations.dart
+++ b/test/test_files/annotations.dart
@@ -56,6 +56,10 @@ class PublicAnnotationClass {
         child2 = const PublicAnnotationClass.withAnIntAsOne();
 }
 
+class ExtendedAnnotationClass extends PublicAnnotationClass {
+  const ExtendedAnnotationClass():super();
+}
+
 class OtherPublicAnnotationClass {
   const OtherPublicAnnotationClass();
 }

--- a/test/test_files/annotations.dart
+++ b/test/test_files/annotations.dart
@@ -60,6 +60,15 @@ class ExtendedAnnotationClass extends PublicAnnotationClass {
   const ExtendedAnnotationClass():super();
 }
 
+class ExtendedAnnotationClassWithForwardedParameters extends PublicAnnotationClass {
+  const ExtendedAnnotationClassWithForwardedParameters(int forwardedInt):super.withPositionalArgs(forwardedInt, 'hello');
+}
+
+class ExtendedAnnotationClassWithCustomAndForwardedParameters extends PublicAnnotationClass {
+  final int customInt;
+  const ExtendedAnnotationClassWithCustomAndForwardedParameters(this.customInt, int forwardedInt):super.withPositionalArgs(forwardedInt, 'hello');
+}
+
 class OtherPublicAnnotationClass {
   const OtherPublicAnnotationClass();
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:mirrors';
 
 import 'package:path/path.dart' as p;
@@ -21,6 +22,10 @@ String getPackagePath() {
 
     _packagePathCache = p.normalize(p.join(p.dirname(currentFilePath), '..'));
   }
+
+  // On Windows, the tests will crash because _packagePathCache starts with a backslash.
+  if (Platform.isWindows && _packagePathCache.startsWith('\\'))
+    _packagePathCache = _packagePathCache.substring(1);
   return _packagePathCache;
 }
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -21,11 +21,10 @@ String getPackagePath() {
         .path;
 
     _packagePathCache = p.normalize(p.join(p.dirname(currentFilePath), '..'));
+    // On Windows, the tests will crash because _packagePathCache starts with a backslash.
+    if (Platform.isWindows && _packagePathCache.startsWith('\\'))
+      _packagePathCache = _packagePathCache.substring(1);
   }
-
-  // On Windows, the tests will crash because _packagePathCache starts with a backslash.
-  if (Platform.isWindows && _packagePathCache.startsWith('\\'))
-    _packagePathCache = _packagePathCache.substring(1);
   return _packagePathCache;
 }
 


### PR DESCRIPTION
I've left details about an error I'm experiencing with source_gen in #155.

This PR will solve one of the two problems I noticed, which is that `instantiateAnnotation` does not work
for annotations that are extended from a parent class.

Please let me know if there is anything I should change before this PR is merged!