### PR TITLE
GeneratorBuilder flag for "part of" without "library".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
   ```
   
   In Dart SDK `>=1.25.0` this can be relaxed as `part of` can refer to a path.
+  To opt-in, `GeneratorBuilder` now has a new flag, `requireLibraryDirective`.
+  Set it to `false`, and also set your `sdk` constraint appropriately:
+  
+  ```yaml
+    sdk: '>=1.25.0 <2.0.0'
+  ```
 
 * Added `findType`, an utility method for `LibraryElement#getType` that also
   traverses `export` directives for publicly exported types. For example, to

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
+import 'package:path/path.dart' as p;
 
 String friendlyNameForElement(Element element) {
   var friendlyName = element.displayName;
@@ -56,7 +57,8 @@ String nameOfPartial(
     return element.name;
   }
   if (allowUnnamedPartials) {
-    return '\'package:${source.package}/${source.path}\'';
+    var sourceUrl = p.basename(source.uri.toString());
+    return '\'$sourceUrl\'';
   }
   return null;
 }

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -75,6 +75,14 @@ void main() {
         throwsA(const isInstanceOf<InvalidGenerationSourceError>()));
   });
 
+  test('Allow no "library" when requireLibraryDirective=false', () async {
+    var sources = _createPackageStub(pkgName, testLibContent: 'class A {}');
+    var builder = new GeneratorBuilder([const CommentGenerator()],
+        requireLibraryDirective: false);
+    await testBuilder(builder, sources,
+        outputs: {'$pkgName|lib/test_lib.g.dart': _testGenNoLibrary});
+  });
+
   test(
       'Simple Generator test for library',
       () => _generateTest(
@@ -305,4 +313,16 @@ part of test_lib;
 // **************************************************************************
 
 // Code for "class Customer"
+''';
+
+const _testGenNoLibrary = r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'test_lib.dart';
+
+// **************************************************************************
+// Generator: CommentGenerator
+// Target: class A
+// **************************************************************************
+
+// Code for "class A"
 ''';


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_gen/issues/157.
Closes https://github.com/dart-lang/source_gen/pull/138.

This approach will not lock-in all future users of `source_gen` to an unreleased `1.25.0`. We can flip the default value in a future (breaking) release.

/cc @davidmorgan 