### PR TITLE
Constants reviver

### DIFF
--- a/lib/source_gen.dart
+++ b/lib/source_gen.dart
@@ -9,4 +9,5 @@ export 'src/constants.dart' show ConstantReader;
 export 'src/generator.dart';
 export 'src/generator_for_annotation.dart';
 export 'src/library.dart' show LibraryReader;
+export 'src/revive.dart' show Revivable, RevivableInstance;
 export 'src/type_checker.dart' show TypeChecker;

--- a/lib/source_gen.dart
+++ b/lib/source_gen.dart
@@ -9,5 +9,5 @@ export 'src/constants.dart' show ConstantReader;
 export 'src/generator.dart';
 export 'src/generator_for_annotation.dart';
 export 'src/library.dart' show LibraryReader;
-export 'src/revive.dart' show Revivable, RevivableInstance;
+export 'src/revive.dart' show Revivable;
 export 'src/type_checker.dart' show TypeChecker;

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -5,6 +5,8 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 
+import 'type_checker.dart';
+
 /// Throws an exception if [root] or its super(s) does not contain [name].
 void _assertHasField(ClassElement root, String name) {
   var element = root;
@@ -95,6 +97,9 @@ abstract class ConstantReader {
   /// Returns whether this constant represents `null`.
   bool get isNull;
 
+  /// Returns whether this constant matches [checker].
+  bool instanceOf(TypeChecker checker);
+
   /// Reads[ field] from the constant as another constant value.
   ConstantReader read(String field);
 }
@@ -141,6 +146,9 @@ class _NullConstant implements ConstantReader {
   bool get isString => false;
 
   @override
+  bool instanceOf(TypeChecker checker) => false;
+
+  @override
   ConstantReader read(_) => throw new UnsupportedError('Null');
 }
 
@@ -176,16 +184,20 @@ class _Constant implements ConstantReader {
   bool get isInt => _object.toIntValue() != null;
 
   @override
-  bool get isList => _object?.toListValue() != null;
+  bool get isList => _object.toListValue() != null;
 
   @override
   bool get isNull => _isNull(_object);
 
   @override
-  bool get isMap => _object?.toMapValue() != null;
+  bool get isMap => _object.toMapValue() != null;
 
   @override
   bool get isString => _object.toStringValue() != null;
+
+  @override
+  bool instanceOf(TypeChecker checker) =>
+      checker.isAssignableFromType(_object.type);
 
   @override
   ConstantReader read(String field) {

--- a/lib/src/revive.dart
+++ b/lib/src/revive.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/constant/value.dart';
+
+import 'utils.dart';
+
+/// Base interface for a meta-analyzed [DartObject].
+abstract class Revivable {}
+
+/// Returns a revivable instance of [object].
+///
+/// Optionally specify the [clazz] type that contains the constructor.
+///
+/// Returns [null] if not revivable.
+RevivableInstance reviveInstance(DartObject object, [ClassElement clazz]) {
+  clazz ??= object.type.element;
+  final url = Uri.parse(urlOfElement(clazz));
+  ClassMemberElement element = _findPublicConstField(object, clazz);
+  if (element != null) {
+    return new RevivableInstance._(source: url, accessor: element.name);
+  }
+  final invocation = _findPublicConstConstructor(object, clazz);
+  if (invocation != null) {
+    return new RevivableInstance._(
+      source: url,
+      accessor: invocation.constructor.name,
+      namedArguments: invocation.namedArguments,
+      positionalArguments: invocation.positionalArguments,
+    );
+  }
+  return null;
+}
+
+FieldElement _findPublicConstField(DartObject object, ClassElement clazz) =>
+    clazz.fields.firstWhere(
+        (f) => f.isConst && f.isPublic && f.computeConstantValue() == object,
+        orElse: () => null);
+
+ConstructorInvocation _findPublicConstConstructor(
+  DartObject object,
+  ClassElement clazz,
+) {
+  final invocation = (object as DartObjectImpl).getInvocation();
+  final constructor = invocation.constructor;
+  if (constructor.isConst && constructor.isPublic) {
+    return invocation;
+  }
+  return null;
+}
+
+/// Decoded "instructions" for re-creating a const [DartObject] at runtime.
+class RevivableInstance implements Revivable {
+  /// A URL pointing to the location and class name.
+  ///
+  /// For example, `LinkedHashMap` looks like: `dart:collection#LinkedHashMap`.
+  final Uri source;
+
+  /// Constructor or getter name used to invoke `const Class(...)`.
+  ///
+  /// Optional - if empty string (`''`) then this means the default constructor.
+  final String accessor;
+
+  /// Positional arguments used to invoke the constructor.
+  final List<DartObject> positionalArguments;
+
+  /// Named arguments used to invoke the constructor.
+  final Map<String, DartObject> namedArguments;
+
+  const RevivableInstance._({
+    this.source,
+    this.accessor: '',
+    this.positionalArguments: const [],
+    this.namedArguments: const {},
+  });
+}

--- a/lib/src/type_checker.dart
+++ b/lib/src/type_checker.dart
@@ -8,6 +8,8 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
+import 'utils.dart';
+
 /// An abstraction around doing static type checking at compile/build time.
 abstract class TypeChecker {
   const TypeChecker._();
@@ -76,51 +78,6 @@ abstract class TypeChecker {
   bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element);
 }
 
-Uri _normalizeUrl(Uri url) {
-  switch (url.scheme) {
-    case 'dart':
-      return _normalizeDartUrl(url);
-    case 'package':
-      return _packageToAssetUrl(url);
-    default:
-      return url;
-  }
-}
-
-/// Make `dart:`-type URLs look like a user-knowable path.
-///
-/// Some internal dart: URLs are something like `dart:core/map.dart`.
-///
-/// This isn't a user-knowable path, so we strip out extra path segments
-/// and only expose `dart:core`.
-Uri _normalizeDartUrl(Uri url) => url.pathSegments.isNotEmpty
-    ? url.replace(pathSegments: url.pathSegments.take(1))
-    : url;
-
-/// Returns a `package:` URL into a `asset:` URL.
-///
-/// This makes internal comparison logic much easier, but still allows users
-/// to define assets in terms of `package:`, which is something that makes more
-/// sense to most.
-///
-/// For example this transforms `package:source_gen/source_gen.dart` into:
-/// `asset:source_gen/lib/source_gen.dart`.
-Uri _packageToAssetUrl(Uri url) => url.scheme == 'package'
-    ? url.replace(
-        scheme: 'asset',
-        pathSegments: <String>[]
-          ..add(url.pathSegments.first)
-          ..add('lib')
-          ..addAll(url.pathSegments.skip(1)))
-    : url;
-
-/// Returns
-String _urlOfElement(Element element) => element.kind == ElementKind.DYNAMIC
-    ? 'dart:core#dynmaic'
-    : _normalizeUrl(element.source.uri)
-        .replace(fragment: element.name)
-        .toString();
-
 // Checks a static type against another static type;
 class _LibraryTypeChecker extends TypeChecker {
   final DartType _type;
@@ -132,13 +89,13 @@ class _LibraryTypeChecker extends TypeChecker {
       element is ClassElement && element == _type.element;
 
   @override
-  String toString() => '${_urlOfElement(_type.element)}';
+  String toString() => '${urlOfElement(_type.element)}';
 }
 
 // Checks a runtime type against a static type.
 class _MirrorTypeChecker extends TypeChecker {
   static Uri _uriOf(ClassMirror mirror) =>
-      _normalizeUrl((mirror.owner as LibraryMirror).uri)
+      normalizeUrl((mirror.owner as LibraryMirror).uri)
           .replace(fragment: MirrorSystem.getName(mirror.simpleName));
 
   // Precomputed type checker for types that already have been used.
@@ -176,14 +133,14 @@ class _UriTypeChecker extends TypeChecker {
   int get hashCode => _url.hashCode;
 
   /// Url as a [Uri] object, lazily constructed.
-  Uri get uri => _cache[this] ??= _normalizeUrl(Uri.parse(_url));
+  Uri get uri => _cache[this] ??= normalizeUrl(Uri.parse(_url));
 
   /// Returns whether this type represents the same as [url].
   bool hasSameUrl(dynamic url) =>
-      uri.toString() == (url is String ? url : _normalizeUrl(url).toString());
+      uri.toString() == (url is String ? url : normalizeUrl(url).toString());
 
   @override
-  bool isExactly(Element element) => hasSameUrl(_urlOfElement(element));
+  bool isExactly(Element element) => hasSameUrl(urlOfElement(element));
 
   @override
   String toString() => '${uri}';

--- a/test/constants_test.dart
+++ b/test/constants_test.dart
@@ -37,6 +37,7 @@ void main() {
         @Super()    // [5]
         @aList      // [6]
         @aMap       // [7]
+        @deprecated // [8]
         class Example {
           final String aString;
           final int aInt;
@@ -119,6 +120,12 @@ void main() {
     test('should fail reading a missing field', () {
       final $super = constants[5];
       expect(() => $super.read('foo'), throwsFormatException);
+    });
+
+    test('should compare using TypeChecker', () {
+      final $deprecated = constants[8];
+      final check = new TypeChecker.fromRuntime(Deprecated);
+      expect($deprecated.instanceOf(check), isTrue, reason: '$deprecated');
     });
   });
 }


### PR DESCRIPTION
Partial support of https://github.com/dart-lang/source_gen/issues/178.

Still missing as of this PR:
* Any sort of sugar for `enum`, though it should work out of the box anyway.
* Error recovery: We just return `null` when something is not resolvable, ideally I'd like to either throw or return a specialized instance (`Unrevivable`) that explains why not (usually due to a private constructor, or not being able to trace how the object was created

Good starting point though I think.