### PR TITLE
increase analyzer min version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.10+1
+
+* Update minimum `analyzer` package to `0.29.10`.
+
 ## 0.5.10
 
 * Bug fixes:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.5.11-dev
+version: 0.5.10+1
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/source_gen
 environment:
   sdk: '>=1.22.1 <2.0.0'
 dependencies:
-  analyzer: '>=0.29.2 <0.31.0'
+  analyzer: '>=0.29.10 <0.31.0'
   build: ^0.9.0
   collection: ^1.1.2
   dart_style: '>=0.1.7 <2.0.0'


### PR DESCRIPTION
`lib/src/revive.dart` line 26 makes a call to DartObjectImpl#getInvocation() which requires [analyzer 0.29.10](https://github.com/dart-lang/sdk/blob/analyzer-0.29/pkg/analyzer/CHANGELOG.md#02910).