### PR TITLE
Add annotationsOfExact.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0
+
+* **Breaking change**: `TypeChecker#annotationsOf|firstAnnotationOf` now
+  returns annotations that are _assignable_ to the `TypeChecker`'s type. As a
+  result we've added `#annotationsOfExact|firstAnnotationOfExact` which has the
+  old behavior for precise checks.
+
 ## 0.5.10+1
 
 * Update minimum `analyzer` package to `0.29.10`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.5.10+1
+version: 0.6.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen

--- a/test/type_checker_test.dart
+++ b/test/type_checker_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// Increase timeouts on this test which resolves source code and can be slow.
+@Timeout.factor(2.0)
 import 'dart:collection';
 
 import 'package:analyzer/dart/element/type.dart';


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_gen/issues/199.

This is a *breaking change*, and has been reflected on the CHANGELOG+pubspec. In reality it should affect a very small number of users, but I would like to get this in so it's used in Angular ASAP (we support inheriting from `@Component` right by accident, we don't want that).