### PR TITLE
Add a warning when 'part' is missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Added `spanForElement`; returns a `SourceSpan` for an analyzer `Element`.
 
+* Logs a _warning_ to the console when a `GeneratorBuilder` outputs a part file
+  for a given input, but that input does not define `part 'name.g.dart';`.
+
 ## 0.6.0
 
 * **Breaking change**: `TypeChecker#annotationsOf|firstAnnotationOf` now

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -98,6 +98,7 @@ class GeneratorBuilder extends Builder {
     // library/part definitions because users expect some files to be skipped
     // therefore they do not have "library".
     if (generatedOutputs.isEmpty) return;
+    final outputId = _generatedFile(buildStep.inputId);
 
     var contentBuffer = new StringBuffer();
     if (!isStandalone) {
@@ -114,6 +115,11 @@ class GeneratorBuilder extends Builder {
             todo: ''
                 'Consider adding the following to your source file:\n\n'
                 'library $suggest;');
+      }
+      final part = computePartUrl(buildStep.inputId, outputId);
+      if (!library.parts.map((c) => c.uri).contains(part)) {
+        // TODO: Upgrade to error in a future breaking change?
+        log.warning('Missing "part \'$part\';".');
       }
       contentBuffer.writeln('part of $name;');
       contentBuffer.writeln();
@@ -138,7 +144,7 @@ class GeneratorBuilder extends Builder {
     } catch (e, stack) {
       log.severe(
           'Error formatting generated source code for ${library.identifier}'
-          'which was output to ${_generatedFile(buildStep.inputId).path}.\n'
+          'which was output to ${outputId.path}.\n'
           'This may indicate an issue in the generated code or in the '
           'formatter.\n'
           'Please check the generated code and file an issue on source_gen if '
@@ -147,8 +153,7 @@ class GeneratorBuilder extends Builder {
           stack);
     }
 
-    buildStep.writeAsString(
-        _generatedFile(buildStep.inputId), '$_topHeader$genPartContent');
+    buildStep.writeAsString(outputId, '$_topHeader$genPartContent');
   }
 
   @override

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -76,6 +76,12 @@ String suggestLibraryName(AssetId source) {
   return '${source.package}.${parts.join('.')}';
 }
 
+/// Returns what 'part "..."' URL is needed to import [output] from [input].
+///
+/// For example, will return `test_lib.g.dart` for `test_lib.dart`.
+String computePartUrl(AssetId input, AssetId output) =>
+    p.joinAll(p.split(p.relative(output.path, from: input.path)).skip(1));
+
 /// Returns a URL representing [element].
 String urlOfElement(Element element) => element.kind == ElementKind.DYNAMIC
     ? 'dart:core#dynmaic'

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -191,8 +191,7 @@ Map<String, String> _createPackageStub(String pkgName,
     {String testLibContent, String testLibPartContent}) {
   return {
     '$pkgName|lib/test_lib.dart': testLibContent ?? _testLibContent,
-    '$pkgName|lib/test_lib.g.dart':
-        testLibPartContent ?? _testLibPartContent,
+    '$pkgName|lib/test_lib.g.dart': testLibPartContent ?? _testLibPartContent,
   };
 }
 

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -119,6 +119,21 @@ void main() {
         });
   });
 
+  test('warns when a non-standalone builder does not see "part"', () async {
+    var srcs =
+        _createPackageStub(pkgName, testLibContent: _testLibContentNoPart);
+    var builder = new GeneratorBuilder([const CommentGenerator()]);
+    var logs = <String>[];
+    await testBuilder(
+      builder,
+      srcs,
+      onLog: (log) {
+        logs.add(log.message);
+      },
+    );
+    expect(logs, ['Missing "part \'test_lib.g.dart\';".']);
+  });
+
   test('defaults to formatting generated code with the DartFormatter',
       () async {
     await testBuilder(new GeneratorBuilder([new UnformattedCodeGenerator()]),
@@ -167,7 +182,8 @@ Future _generateTest(CommentGenerator gen, String expectedContent) async {
       generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
       outputs: {
         '$pkgName|lib/test_lib.g.dart': expectedContent,
-      });
+      },
+      onLog: (log) => fail('Unexpected log message: ${log.message}'));
 }
 
 /// Creates a package using [pkgName].
@@ -175,7 +191,7 @@ Map<String, String> _createPackageStub(String pkgName,
     {String testLibContent, String testLibPartContent}) {
   return {
     '$pkgName|lib/test_lib.dart': testLibContent ?? _testLibContent,
-    '$pkgName|lib/test_lib_part.dart':
+    '$pkgName|lib/test_lib.g.dart':
         testLibPartContent ?? _testLibPartContent,
   };
 }
@@ -200,14 +216,20 @@ const pkgName = 'pkg';
 
 const _testLibContent = r'''
 library test_lib;
-part 'test_lib_part.dart';
+part 'test_lib.g.dart';
+final int foo = 42;
+class Person { }
+''';
+
+const _testLibContentNoPart = r'''
+library test_lib;
 final int foo = 42;
 class Person { }
 ''';
 
 const _testLibContentWithError = r'''
 library test_lib;
-part 'test_lib_part.dart';
+part 'test_lib.g.dart';
 class MyError { }
 class MyGoodError { }
 ''';

--- a/test/span_for_element_test.dart
+++ b/test/span_for_element_test.dart
@@ -12,11 +12,13 @@ void main() {
   LibraryElement library;
 
   setUpAll(() async {
-    final resolver = await resolveSource(r'''
+    final resolver = await resolveSource(
+        r'''
       library test_lib;
       
       abstract class Example implements List {}
-    ''', inputId: new AssetId('test_lib', 'lib/test_lib.dart'));
+    ''',
+        inputId: new AssetId('test_lib', 'lib/test_lib.dart'));
     library = resolver.getLibraryByName('test_lib');
   });
 

--- a/test/span_for_element_test.dart
+++ b/test/span_for_element_test.dart
@@ -13,12 +13,13 @@ void main() {
 
   setUpAll(() async {
     final resolver = await resolveSource(
-        r'''
+      r'''
       library test_lib;
-      
+
       abstract class Example implements List {}
     ''',
-        inputId: new AssetId('test_lib', 'lib/test_lib.dart'));
+      inputId: new AssetId('test_lib', 'lib/test_lib.dart'),
+    );
     library = resolver.getLibraryByName('test_lib');
   });
 


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_gen/issues/7.

I tested the positive and negative cases on the existing `builder_test` cases, and there were some failures (probably when `.g.dart` wasn't the norm yet), so I updated those test cases. Now they will fail if anything is logged to the console, and added a test that checks something _is_ logged when the `part` definition is missing.

I wanted to do `severe`, but we should validate internally first me thinks.