### PR TITLE
Tighten constraint on source_span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.6.1+1
+
+* Tighten constraint on `source_span`.
+
 ## 0.6.1
 
 * Added `spanForElement`; returns a `SourceSpan` for an analyzer `Element`.
-
 * Logs a _warning_ to the console when a `GeneratorBuilder` outputs a part file
   for a given input, but that input does not define `part 'name.g.dart';`.
 
@@ -11,11 +14,9 @@
   returns annotations that are _assignable_ to the `TypeChecker`'s type. As a
   result we've added `#annotationsOfExact|firstAnnotationOfExact` which has the
   old behavior for precise checks.
-
 * `TypeChecker#annotations...`-methods now throw a `StateError` if one or more
   annotations on an element are not resolvable. This is usually a sign of a
   mispelling, missing import, or missing dependency.
-  
 * Added `TypeChecker.any`, which delegates to multiple other `TypeChecker`
   implementations when making a type check.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.6.1
+version: 0.6.1+1
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.1.2
   dart_style: '>=0.1.7 <2.0.0'
   path: ^1.3.2
-  source_span: ^1.0.0
+  source_span: ^1.4.0
 dev_dependencies:
   build_runner: ^0.3.2
   build_test: ^0.6.0


### PR DESCRIPTION
Currently it's possible to resolve to a version that won't work because
it's missing the `SourceFile.fromString()` constructor.