### PR TITLE
Drop the safeIterate helper

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -162,10 +162,14 @@ class GeneratorBuilder extends Builder {
 
 Stream<GeneratedOutput> _generate(LibraryElement unit,
     List<Generator> generators, BuildStep buildStep) async* {
-  var elements = safeIterate(getElementsFromLibraryElement(unit), (e, [_]) {
+  List<Element> elements;
+  try {
+    elements = getElementsFromLibraryElement(unit).toList();
+  } catch (e) {
     log.fine('Resolve error details:\n$e');
     log.severe('Failed to resolve ${buildStep.inputId}.');
-  });
+    return;
+  }
   for (var element in elements) {
     yield* _processUnitMember(element, generators, buildStep);
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -157,20 +157,6 @@ Iterable<Element> getElementsFromLibraryElement(LibraryElement unit) sync* {
   }
 }
 
-/// Returns an Iterable that will not throw any exceptions while iterating.
-///
-/// If an exception occurs while iterating [iterable] the return value will
-/// finish and [onError] will be called.
-Iterable<T> safeIterate<T>(Iterable<T> iterable, void onError(e, st)) sync* {
-  try {
-    for (var e in iterable) {
-      yield e;
-    }
-  } catch (e, st) {
-    onError(e, st);
-  }
-}
-
 Iterable<Element> _getElements(CompilationUnitMember member) {
   if (member is TopLevelVariableDeclaration) {
     return member.variables.variables


### PR DESCRIPTION
This existed so that we could separate the exceptions that occur during
iteration from the exceptions that occur during processing since a for
loop can't have a try/catch around only getting elemetns. This is more
easily expressed with a try/catch around `Iterable.toList()`.