### PR TITLE
Rename and expose allElements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   * Removed `JsonSerializable` and related classes. These are moved to
     `package:json_serializable`.
   * Removed `lib/builder.dart`. Import through `source_gen.dart` instead.
+* Expose `allElements` - a utility to iterate across all `Element` instances
+  contained in a `LibraryElement`.
 
 ## 0.6.1+1
 

--- a/lib/source_gen.dart
+++ b/lib/source_gen.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+library source_gen;
+
 export 'src/builder.dart';
 export 'src/constants.dart' show ConstantReader;
 export 'src/generator.dart';

--- a/lib/source_gen.dart
+++ b/lib/source_gen.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library source_gen;
-
 export 'src/builder.dart';
 export 'src/constants.dart' show ConstantReader;
 export 'src/generator.dart';
@@ -12,3 +10,4 @@ export 'src/library.dart' show LibraryReader;
 export 'src/revive.dart' show Revivable;
 export 'src/span_for_element.dart' show spanForElement;
 export 'src/type_checker.dart' show TypeChecker;
+export 'src/utils.dart' show allElements;

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -164,7 +164,7 @@ Stream<GeneratedOutput> _generate(LibraryElement unit,
     List<Generator> generators, BuildStep buildStep) async* {
   List<Element> elements;
   try {
-    elements = getElementsFromLibraryElement(unit).toList();
+    elements = allElements(unit).toList();
   } catch (e) {
     log.fine('Resolve error details:\n$e');
     log.severe('Failed to resolve ${buildStep.inputId}.');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -146,11 +146,11 @@ Uri assetToPackageUrl(Uri url) => url.scheme == 'asset' &&
           ..addAll(url.pathSegments.skip(2)))
     : url;
 
-/// Returns all of the declarations in [unit], including [unit] as the first
-/// item.
-Iterable<Element> getElementsFromLibraryElement(LibraryElement unit) sync* {
-  yield unit;
-  for (var cu in unit.units) {
+/// Returns all of the declarations in [library], including [library] as the
+/// first item.
+Iterable<Element> allElements(LibraryElement library) sync* {
+  yield library;
+  for (var cu in library.units) {
     for (var compUnitMember in cu.unit.declarations) {
       yield* _getElements(compUnitMember);
     }


### PR DESCRIPTION
This is a necessary utility as we change `Generator` to take a
`LibraryElement` in #223