### PR TITLE
Add separate classes for Part vs Library builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
   * `GeneratorForAnnotation` passes in a `ConstantReader` for the annotation
     instance rather than re-creating it using mirrors.
   * `GeneratorBuilder` is replaced with `PartBuilder` and `LibraryBuilder`
-    depending on whether the `Generator`(s) used are meant to be included in a
-    `part` file.
+    depending on whether the output is meant to be included in a `part` file.
   * Removed `JsonSerializable` and related classes. These are moved to
     `package:json_serializable`.
   * Removed `lib/builder.dart`. Import through `source_gen.dart` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
     continue to call `generateForAnnotatedElement` repeatedly for each element.
   * `GeneratorForAnnotation` passes in a `ConstantReader` for the annotation
     instance rather than re-creating it using mirrors.
+  * `GeneratorBuilder` is replaced with `PartBuilder` and `LibraryBuilder`
+    depending on whether the `Generator`(s) used are meant to be included in a
+    `part` file.
   * Removed `JsonSerializable` and related classes. These are moved to
     `package:json_serializable`.
   * Removed `lib/builder.dart`. Import through `source_gen.dart` instead.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ standalone tools like [build_runner][]. You could also build your own.
 
 Meanwhile, `source_gen` provides an API and tooling that is easily usable on
 top of `build` to make common tasks easier and more developer friendly. For
-example the [`GeneratorBuilder`][api:GeneratorBuilder] class wraps one or
-more [`Generator`][api:Generator] instances to make a [`Builder`][api:Builder].
+example the [`PartBuilder`][api:PartBuilder] class wraps one or more
+[`Generator`][api:Generator] instances to make a [`Builder`][api:Builder] which
+creates `part of` files, while the [`LibraryBuilder`][api:LibraryBuilder] class
+wraps a single Generator to make a `Builder` which creates Dart library files.
 
 ### What is the difference between `source_gen` and transformers?
 
@@ -115,7 +117,8 @@ detail*.
 <!-- Dartdoc -->
 [api:Builder]: https://www.dartdocs.org/documentation/build/latest/builder/Builder-class.html
 [api:Generator]: https://www.dartdocs.org/documentation/source_gen/latest/builder/Generator-class.html
-[api:GeneratorBuilder]: https://www.dartdocs.org/documentation/source_gen/latest/builder/GeneratorBuilder-class.html
+[api:PartBuilder]: https://www.dartdocs.org/documentation/source_gen/latest/builder/PartBuilder-class.html
+[api:LibraryBuilder]: https://www.dartdocs.org/documentation/source_gen/latest/builder/LibraryBuilder-class.html
 
 [Dart transformers]: https://www.dartlang.org/tools/pub/assets-and-transformers.html
 [Trivial example]: https://github.com/dart-lang/source_gen/blob/master/test/src/comment_generator.dart

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -1,4 +1,5 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -15,16 +16,8 @@ import 'utils.dart';
 /// Returns [generatedCode] formatted, usually with something like `dartfmt`.
 typedef String OutputFormatter(String generatedCode);
 
-/// Wraps multiple [Generator]s and exposes them as a [Builder] for tooling.
-///
-/// ```dart
-/// // Creates a new builder that the following two generators.
-/// new GeneratorBuilder([
-///   new JsonSerializableGenerator(),
-///   new JsonLiteralGenerator(),
-/// ]);
-/// ```
-class GeneratorBuilder extends Builder {
+/// A [Builder] wrapping on one or more [Generator]s.
+class _Builder extends Builder {
   /// Function that determines how the generated code is formatted.
   final OutputFormatter formatOutput;
 
@@ -50,7 +43,7 @@ class GeneratorBuilder extends Builder {
   /// ```yaml
   /// sdk: '>=1.25.0 <2.0.0'
   /// ```
-  GeneratorBuilder(this.generators,
+  _Builder(this.generators,
       {OutputFormatter formatOutput,
       this.generatedExtension: '.g.dart',
       this.isStandalone: false,
@@ -153,9 +146,26 @@ class GeneratorBuilder extends Builder {
 
     buildStep.writeAsString(outputId, '$_topHeader$genPartContent');
   }
+}
 
-  @override
-  String toString() => 'GeneratorBuilder:$generators';
+class PartBuilder extends _Builder {
+  PartBuilder(List<Generator> generators,
+      {OutputFormatter formatOutput,
+      String generatedExtension: '.g.dart',
+      bool requireLibraryDirective: true})
+      : super(generators,
+            formatOutput: formatOutput,
+            generatedExtension: generatedExtension,
+            requireLibraryDirective: requireLibraryDirective);
+}
+
+class LibraryBuilder extends _Builder {
+  LibraryBuilder(Generator generator,
+      {OutputFormatter formatOutput, String generatedExtension: '.g.dart'})
+      : super([generator],
+            formatOutput: formatOutput,
+            generatedExtension: generatedExtension,
+            isStandalone: true);
 }
 
 Stream<GeneratedOutput> _generate(LibraryElement library,

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   test('Bad generated source', () async {
     var srcs = _createPackageStub(pkgName);
-    var builder = new GeneratorBuilder([const _BadOutputGenerator()]);
+    var builder = new PartBuilder([const _BadOutputGenerator()]);
 
     await testBuilder(builder, srcs,
         generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
@@ -32,8 +32,7 @@ void main() {
 
   test('Generate standalone output file', () async {
     var srcs = _createPackageStub(pkgName);
-    var builder =
-        new GeneratorBuilder([const CommentGenerator()], isStandalone: true);
+    var builder = new LibraryBuilder(const CommentGenerator());
     await testBuilder(builder, srcs,
         generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
         outputs: {
@@ -41,37 +40,17 @@ void main() {
         });
   });
 
-  test('Generate explicitly non-standalone output file', () async {
-    var srcs = _createPackageStub(pkgName);
-    var builder =
-        new GeneratorBuilder([const CommentGenerator()], isStandalone: false);
-    await testBuilder(builder, srcs,
-        generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
-        outputs: {
-          '$pkgName|lib/test_lib.g.dart': _testGenPartContent,
-        });
-  });
-
-  test('Expect error when multiple generators used on a standalone builder',
-      () async {
-    expect(
-        () => new GeneratorBuilder(
-            [const CommentGenerator(), const _NoOpGenerator()],
-            isStandalone: true),
-        throwsA(new isInstanceOf<ArgumentError>()));
-  });
-
   test('Expect no error when multiple generators used on nonstandalone builder',
       () async {
     expect(
-        () => new GeneratorBuilder(
-            [const CommentGenerator(), const _NoOpGenerator()]),
+        () =>
+            new PartBuilder([const CommentGenerator(), const _NoOpGenerator()]),
         returnsNormally);
   });
 
   test('Throws an exception when no library identifier is found', () async {
     var sources = _createPackageStub(pkgName, testLibContent: 'class A {}');
-    var builder = new GeneratorBuilder([const CommentGenerator()]);
+    var builder = new PartBuilder([const CommentGenerator()]);
     expect(
         testBuilder(builder, sources,
             outputs: {'$pkgName|lib/test_lib.g.dart': ''}),
@@ -80,14 +59,13 @@ void main() {
 
   test('Does not fail when there is no output', () async {
     var sources = _createPackageStub(pkgName, testLibContent: 'class A {}');
-    var builder =
-        new GeneratorBuilder([new CommentGenerator(forClasses: false)]);
+    var builder = new PartBuilder([new CommentGenerator(forClasses: false)]);
     await testBuilder(builder, sources, outputs: {});
   });
 
   test('Allow no "library" when requireLibraryDirective=false', () async {
     var sources = _createPackageStub(pkgName, testLibContent: 'class A {}');
-    var builder = new GeneratorBuilder([const CommentGenerator()],
+    var builder = new PartBuilder([const CommentGenerator()],
         requireLibraryDirective: false);
     await testBuilder(builder, sources,
         outputs: {'$pkgName|lib/test_lib.g.dart': _testGenNoLibrary});
@@ -107,14 +85,14 @@ void main() {
 
   test('No-op generator produces no generated parts', () async {
     var srcs = _createPackageStub(pkgName);
-    var builder = new GeneratorBuilder([const _NoOpGenerator()]);
+    var builder = new PartBuilder([const _NoOpGenerator()]);
     await testBuilder(builder, srcs, outputs: {});
   });
 
   test('handle generator errors well', () async {
     var srcs =
         _createPackageStub(pkgName, testLibContent: _testLibContentWithError);
-    var builder = new GeneratorBuilder([const CommentGenerator()]);
+    var builder = new PartBuilder([const CommentGenerator()]);
     await testBuilder(builder, srcs,
         generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
         outputs: {
@@ -125,7 +103,7 @@ void main() {
   test('warns when a non-standalone builder does not see "part"', () async {
     var srcs =
         _createPackageStub(pkgName, testLibContent: _testLibContentNoPart);
-    var builder = new GeneratorBuilder([const CommentGenerator()]);
+    var builder = new PartBuilder([const CommentGenerator()]);
     var logs = <String>[];
     await testBuilder(
       builder,
@@ -139,7 +117,7 @@ void main() {
 
   test('defaults to formatting generated code with the DartFormatter',
       () async {
-    await testBuilder(new GeneratorBuilder([new UnformattedCodeGenerator()]),
+    await testBuilder(new PartBuilder([new UnformattedCodeGenerator()]),
         {'$pkgName|lib/a.dart': 'library a; part "a.part.dart";'},
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
         outputs: {
@@ -150,7 +128,7 @@ void main() {
 
   test('can skip formatting with a trivial lambda', () async {
     await testBuilder(
-        new GeneratorBuilder([new UnformattedCodeGenerator()],
+        new PartBuilder([new UnformattedCodeGenerator()],
             formatOutput: (s) => s),
         {'$pkgName|lib/a.dart': 'library a; part "a.part.dart";'},
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
@@ -163,7 +141,7 @@ void main() {
   test('can pass a custom formatter with formatOutput', () async {
     var customOutput = 'final String hello = "hello";';
     await testBuilder(
-        new GeneratorBuilder([new UnformattedCodeGenerator()],
+        new PartBuilder([new UnformattedCodeGenerator()],
             formatOutput: (_) => customOutput),
         {'$pkgName|lib/a.dart': 'library a; part "a.part.dart";'},
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
@@ -175,7 +153,7 @@ void main() {
 
 Future _generateTest(CommentGenerator gen, String expectedContent) async {
   var srcs = _createPackageStub(pkgName);
-  var builder = new GeneratorBuilder([gen]);
+  var builder = new PartBuilder([gen]);
 
   await testBuilder(builder, srcs,
       generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),


### PR DESCRIPTION
Closes #117

Fixes the API weirdness where `isStandalone` only works with a single
Generator, and shouldn't be passed with `requireLibraryDirective`.

This is a small step - we still need to clean up the interface (#219).

- Make `GeneratorBuilder` private as `_Builder`.
- Subclass as `PartBuilder` and `LibraryBuilder` with only forwarding
  constructors to give nicer signatures.