### PR TITLE
Move allElements to LibraryReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
     `package:json_serializable`.
   * Removed `lib/builder.dart`. Import through `source_gen.dart` instead.
   * Removed `OutputFormatter` typedef.
-* Expose `allElements` - a utility to iterate across all `Element` instances
-  contained in a `LibraryElement`.
+* Add `LibraryReader.allElements` - a utility to iterate across all `Element`
+  instances contained in Dart library.
 
 ## 0.6.1+1
 

--- a/lib/source_gen.dart
+++ b/lib/source_gen.dart
@@ -12,4 +12,3 @@ export 'src/library.dart' show LibraryReader;
 export 'src/revive.dart' show Revivable;
 export 'src/span_for_element.dart' show spanForElement;
 export 'src/type_checker.dart' show TypeChecker;
-export 'src/utils.dart' show allElements;

--- a/lib/src/generator_for_annotation.dart
+++ b/lib/src/generator_for_annotation.dart
@@ -10,8 +10,8 @@ import 'package:build/build.dart';
 
 import 'constants.dart';
 import 'generator.dart';
+import 'library.dart';
 import 'type_checker.dart';
-import 'utils.dart';
 
 /// A [Generator] that invokes [generateForAnnotatedElement] for every [T].
 ///
@@ -36,7 +36,7 @@ abstract class GeneratorForAnnotation<T> extends Generator {
 
   @override
   Future<String> generate(LibraryElement library, BuildStep buildStep) async {
-    var elements = allElements(library)
+    var elements = new LibraryReader(library).allElements
         .map((e) => new _AnnotatedElement(e, typeChecker.firstAnnotationOf(e)))
         .where((e) => e.annotation != null);
     var allOutput = await Future.wait(elements.map((e) =>

--- a/lib/src/generator_for_annotation.dart
+++ b/lib/src/generator_for_annotation.dart
@@ -36,7 +36,8 @@ abstract class GeneratorForAnnotation<T> extends Generator {
 
   @override
   Future<String> generate(LibraryElement library, BuildStep buildStep) async {
-    var elements = new LibraryReader(library).allElements
+    var elements = new LibraryReader(library)
+        .allElements
         .map((e) => new _AnnotatedElement(e, typeChecker.firstAnnotationOf(e)))
         .where((e) => e.annotation != null);
     var allOutput = await Future.wait(elements.map((e) =>

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -145,29 +145,3 @@ Uri assetToPackageUrl(Uri url) => url.scheme == 'asset' &&
         pathSegments: [url.pathSegments.first]
           ..addAll(url.pathSegments.skip(2)))
     : url;
-
-/// Returns all of the declarations in [library], including [library] as the
-/// first item.
-Iterable<Element> allElements(LibraryElement library) sync* {
-  yield library;
-  for (var cu in library.units) {
-    for (var compUnitMember in cu.unit.declarations) {
-      yield* _getElements(compUnitMember);
-    }
-  }
-}
-
-Iterable<Element> _getElements(CompilationUnitMember member) {
-  if (member is TopLevelVariableDeclaration) {
-    return member.variables.variables
-        .map(resolutionMap.elementDeclaredByVariableDeclaration);
-  }
-  var element = resolutionMap.elementDeclaredByDeclaration(member);
-
-  if (element == null) {
-    print([member, member.runtimeType, member.element]);
-    throw new Exception('Could not find any elements for the provided unit.');
-  }
-
-  return [element];
-}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:path/path.dart' as p;

--- a/test/src/comment_generator.dart
+++ b/test/src/comment_generator.dart
@@ -20,8 +20,9 @@ class CommentGenerator extends Generator {
       output.writeln('// Code for "$library"');
     }
     if (forClasses) {
-      for (var classElement
-          in allElements(library).where((e) => e is ClassElement)) {
+      for (var classElement in new LibraryReader(library)
+          .allElements
+          .where((e) => e is ClassElement)) {
         if (classElement.displayName.contains('GoodError')) {
           throw new InvalidGenerationSourceError(
               "Don't use classes with the word 'Error' in the name",


### PR DESCRIPTION
Fixes #229

LibraryReader is a nicer place for this utility and will give us a
surface to attach more functionality than scattering top-level methods.