### PR TITLE
Prune dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,16 +8,14 @@ environment:
 dependencies:
   analyzer: '>=0.29.10 <0.31.0'
   build: ^0.9.0
-  collection: ^1.1.2
   dart_style: '>=0.1.7 <2.0.0'
   path: ^1.3.2
   source_span: ^1.4.0
 dev_dependencies:
-  build_runner: ^0.3.2
   build_test: ^0.6.0
+  collection: ^1.1.2
   cli_util: '>=0.1.0 <0.2.0'
   meta: ^1.0.5
-  mockito: '>=0.11.0 <3.0.0'
   test: ^0.12.3
   _test_annotations:
     path: ./_test_annotations


### PR DESCRIPTION
- package:collection is only used under test/ so move it to
  dev_dependencies.
- Drop dev_dependencies on no-longer used package build_runner and
  mockito.