### PR TITLE
Don't emit library in allElements

### DIFF
--- a/lib/src/library.dart
+++ b/lib/src/library.dart
@@ -29,7 +29,6 @@ class LibraryReader {
   /// All of the declarations in this library, including the [LibraryElement] as
   /// the first item.
   Iterable<Element> get allElements sync* {
-    yield element;
     for (var cu in element.units) {
       for (var compUnitMember in cu.unit.declarations) {
         yield* _getElements(compUnitMember);

--- a/lib/src/library.dart
+++ b/lib/src/library.dart
@@ -26,8 +26,7 @@ class LibraryReader {
   ClassElement findType(String name) =>
       element.getType(name) ?? _namespace.get(name) as ClassElement;
 
-  /// All of the declarations in this library, including the [LibraryElement] as
-  /// the first item.
+  /// All of the declarations in this library.
   Iterable<Element> get allElements sync* {
     for (var cu in element.units) {
       for (var compUnitMember in cu.unit.declarations) {


### PR DESCRIPTION
Fixes #245

The library is available through `element` and most Generators will want
to make a distinction anyway.