### PR TITLE
Support latest package:build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2+1
+
+* Allow `package:build` version 0.11.0
+
 ## 0.7.2
 
 * Support an optional `header` argument to `PartBuilder` and `LibraryBuilder`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.7.2
+version: 0.7.2+1
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen
@@ -7,13 +7,13 @@ environment:
   sdk: '>=1.22.1 <2.0.0'
 dependencies:
   analyzer: '>=0.29.10 <0.31.0'
-  build: ^0.10.0
+  build: '>=0.10.0 <0.12.0'
   dart_style: '>=0.1.7 <2.0.0'
   meta: ^1.1.0
   path: ^1.3.2
   source_span: ^1.4.0
 dev_dependencies:
-  build_test: '>=0.7.0 <0.9.0'
+  build_test: ^0.9.0
   collection: ^1.1.2
   cli_util: '>=0.1.0 <0.2.0'
   logging: ^0.11.3

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -26,7 +26,8 @@ void main() {
     await testBuilder(builder, srcs,
         generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
         outputs: {
-          '$pkgName|lib/test_lib.g.dart': contains('not valid code!'),
+          '$pkgName|lib/test_lib.g.dart':
+              decodedMatches(contains('not valid code!')),
         });
   });
 
@@ -48,7 +49,7 @@ void main() {
         generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
         outputs: {
           '$pkgName|lib/test_lib.g.dart':
-              startsWith(_customHeader + '\n\n// ***')
+              decodedMatches(startsWith(_customHeader + '\n\n// ***'))
         });
   });
 
@@ -57,7 +58,9 @@ void main() {
     var builder = new LibraryBuilder(const CommentGenerator(), header: '');
     await testBuilder(builder, srcs,
         generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
-        outputs: {'$pkgName|lib/test_lib.g.dart': startsWith('// ***')});
+        outputs: {
+          '$pkgName|lib/test_lib.g.dart': decodedMatches(startsWith('// ***'))
+        });
   });
 
   test('Expect no error when multiple generators used on nonstandalone builder',
@@ -142,7 +145,7 @@ void main() {
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
         outputs: {
           '$pkgName|lib/a.g.dart':
-              contains(UnformattedCodeGenerator.formattedCode),
+              decodedMatches(contains(UnformattedCodeGenerator.formattedCode)),
         });
   });
 
@@ -153,7 +156,8 @@ void main() {
         {'$pkgName|lib/a.dart': 'library a; part "a.part.dart";'},
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
         outputs: {
-          '$pkgName|lib/a.g.dart': startsWith(_customHeader + '\npart of'),
+          '$pkgName|lib/a.g.dart':
+              decodedMatches(startsWith(_customHeader + '\npart of')),
         });
   });
 
@@ -163,7 +167,7 @@ void main() {
         {'$pkgName|lib/a.dart': 'library a; part "a.part.dart";'},
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
         outputs: {
-          '$pkgName|lib/a.g.dart': startsWith('part of'),
+          '$pkgName|lib/a.g.dart': decodedMatches(startsWith('part of')),
         });
   });
 
@@ -174,8 +178,8 @@ void main() {
         {'$pkgName|lib/a.dart': 'library a; part "a.part.dart";'},
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
         outputs: {
-          '$pkgName|lib/a.g.dart':
-              contains(UnformattedCodeGenerator.unformattedCode),
+          '$pkgName|lib/a.g.dart': decodedMatches(
+              contains(UnformattedCodeGenerator.unformattedCode)),
         });
   });
 
@@ -187,7 +191,7 @@ void main() {
         {'$pkgName|lib/a.dart': 'library a; part "a.part.dart";'},
         generateFor: new Set.from(['$pkgName|lib/a.dart']),
         outputs: {
-          '$pkgName|lib/a.g.dart': contains(customOutput),
+          '$pkgName|lib/a.g.dart': decodedMatches(contains(customOutput)),
         });
   });
 
@@ -209,7 +213,7 @@ Future _generateTest(CommentGenerator gen, String expectedContent) async {
   await testBuilder(builder, srcs,
       generateFor: new Set.from(['$pkgName|lib/test_lib.dart']),
       outputs: {
-        '$pkgName|lib/test_lib.g.dart': expectedContent,
+        '$pkgName|lib/test_lib.g.dart': decodedMatches(expectedContent),
       },
       onLog: (log) => fail('Unexpected log message: ${log.message}'));
 }


### PR DESCRIPTION
Update to `build_test` v 0.9.0 and update tests to use `decodedMatches`