### PR TITLE
Handle empty outputs in GenerateForAnntation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3
+
+* Allow null and empty outputs form `GeneratorForAnnotation`.
+
 ## 0.7.2+1
 
 * Allow `package:build` version 0.11.0

--- a/lib/src/generator_for_annotation.dart
+++ b/lib/src/generator_for_annotation.dart
@@ -39,7 +39,7 @@ abstract class GeneratorForAnnotation<T> extends Generator {
     var allOutput = await Future.wait(elements.map((e) async =>
         await generateForAnnotatedElement(e.element, e.annotation, buildStep)));
     // TODO interleave comments indicating which element produced the output?
-    return allOutput.join('\n');
+    return allOutput.where((o) => o != null && o.isNotEmpty).join('\n');
   }
 
   /// Override to return source code to generate for [element].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.7.2+1
+version: 0.7.3
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen

--- a/test/generator_for_annotation_test.dart
+++ b/test/generator_for_annotation_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+import 'package:source_gen/source_gen.dart';
+
+void main() {
+  test('Skips output if per-annotation output is empty', () async {
+    final generator = new NoOutput();
+    var builder = new LibraryBuilder(generator);
+    await testBuilder(builder, {
+      'a|lib/file.dart': '''
+     @deprecated
+     final foo = 'foo';
+     '''
+    }, outputs: {});
+  });
+}
+
+class NoOutput extends GeneratorForAnnotation<Deprecated> {
+  @override
+  FutureOr<String> generateForAnnotatedElement(
+          Element element, ConstantReader annotation, BuildStep buildStep) =>
+      null;
+}


### PR DESCRIPTION
Fixes #285

Previously if the library had any matching annotations we would always
output something - either the String "null" or empty lines.

Skip outputs that are null or empty. Add a regression test.