### PR TITLE
Add LibraryReader.pathToUrl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.4-dev
+
+* Added `LibraryReader.pathToUrl(Uri|String)`, which computes the `import` or
+  `export` path necessary to reach the provided URL from the current library.
+
 ## 0.7.3
 
 * Allow null and empty outputs form `GeneratorForAnnotation`.

--- a/lib/src/library.dart
+++ b/lib/src/library.dart
@@ -78,6 +78,11 @@ class LibraryReader {
   /// the library, falling back to relative paths if required (such as in the
   /// `test` directory).
   ///
+  /// The support [Uri.scheme]s are (others throw [ArgumentError]):
+  /// * `dart`
+  /// * `package`
+  /// * `asset`
+  ///
   /// May throw [ArgumentError] if it is not possible to resolve a path.
   Uri pathToUrl(dynamic toUrlOrString) {
     final to = toUrlOrString is Uri

--- a/lib/src/library.dart
+++ b/lib/src/library.dart
@@ -7,9 +7,11 @@ import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/resolver/scope.dart';
+import 'package:path/path.dart' as p;
 
 import 'constants/reader.dart';
 import 'type_checker.dart';
+import 'utils.dart';
 
 /// Result of finding an [annotation] on [element] through [LibraryReader].
 class AnnotatedElement {
@@ -68,6 +70,77 @@ class LibraryReader {
         yield new AnnotatedElement(new ConstantReader(annotation), element);
       }
     }
+  }
+
+  /// Returns a [Uri] from the current library to the one provided.
+  ///
+  /// If possible, a `package:` or `dart:` URL scheme will be used to reference
+  /// the library, falling back to relative paths if required (such as in the
+  /// `test` directory).
+  ///
+  /// May throw [ArgumentError] if it is not possible to resolve a path.
+  Uri pathToUrl(dynamic toUrlOrString) {
+    final to = toUrlOrString is Uri
+        ? toUrlOrString
+        : Uri.parse(toUrlOrString as String);
+    if (to.scheme == 'dart') {
+      // Convert dart:core/map.dart to dart:core.
+      return normalizeDartUrl(to);
+    }
+    if (to.scheme == 'package') {
+      // Identity (no-op).
+      return to;
+    }
+    if (to.scheme == 'asset') {
+      // This is the same thing as a package: URL.
+      //
+      // i.e.
+      //   asset:foo/lib/foo.dart ===
+      //   package:foo/foo.dart
+      if (to.pathSegments.length > 1 && to.pathSegments[1] == 'lib') {
+        return assetToPackageUrl(to);
+      }
+      var from = element.source.uri;
+      if (from == null) {
+        throw new StateError('Current library has no source URL');
+      }
+      // Normalize (convert to an asset: URL).
+      from = normalizeUrl(from);
+      if (_isRelative(from, to)) {
+        if (from == to) {
+          // Edge-case: p.relative('a.dart', 'a.dart') == '.', but that is not
+          // a valid import URL in Dart source code.
+          return new Uri(path: to.pathSegments.last);
+        }
+        final relative = Uri.parse(p.relative(
+          to.toString(),
+          from: from.toString(),
+        ));
+        // We now have a URL like "../b.dart", but we just want "b.dart".
+        return relative.replace(
+          pathSegments: relative.pathSegments.skip(1),
+        );
+      }
+      throw new ArgumentError.value(to, 'to', 'Not relative to $from');
+    }
+    throw new ArgumentError.value(to, 'to', 'Cannot use scheme "${to.scheme}"');
+  }
+
+  /// Returns whether both [from] and [to] are in the same package and folder.
+  ///
+  /// For example these are considered relative:
+  /// * `asset:foo/test/foo.dart` and `asset:foo/test/bar.dart`.
+  ///
+  /// But these are not:
+  /// * `asset:foo/test/foo.dart` and `asset:foo/bin/bar.dart`.
+  /// * `asset:foo/test/foo.dart` and `asset:bar/test/foo.dart`.
+  static bool _isRelative(Uri from, Uri to) {
+    final fromSegments = from.pathSegments;
+    final toSegments = to.pathSegments;
+    return fromSegments.length >= 2 &&
+        toSegments.length >= 2 &&
+        fromSegments[0] == toSegments[0] &&
+        fromSegments[1] == toSegments[1];
   }
 
   /// All of the `class` elements in this library.

--- a/test/library/path_to_url_test.dart
+++ b/test/library/path_to_url_test.dart
@@ -1,0 +1,186 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Increase timeouts on this test which resolves source code and can be slow.
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/generated/source_io.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  LibraryReader reader;
+
+  final packageA = Uri.parse('package:a/a.dart');
+  final packageB = Uri.parse('package:b/b.dart');
+  final assetPackageA = Uri.parse('asset:a/lib/a.dart');
+  final assetPackageB = Uri.parse('asset:b/lib/b.dart');
+  final packageATestDir = Uri.parse('asset:a/test/a.dart');
+  final packageATestDirFileB = Uri.parse('asset:a/test/b.dart');
+  final packageATestDirDeepFile = Uri.parse('asset:a/test/in/a/folder/a.dart');
+  final packageBTestDir = Uri.parse('asset:b/test/b.dart');
+  final dartAsync = Uri.parse('dart:async');
+  final dartAsyncPrivate = Uri.parse('dart:async/zone.dart');
+
+  group('from a package URL to', () {
+    setUpAll(() {
+      reader = new LibraryReader(new _FakeLibraryElement(packageA));
+    });
+
+    test('a dart SDK library', () {
+      expect(reader.pathToUrl(dartAsync), dartAsync);
+    });
+
+    test('a dart SDK private library', () {
+      expect(reader.pathToUrl(dartAsyncPrivate), dartAsync);
+    });
+
+    test('the same package', () {
+      expect(reader.pathToUrl(packageA), packageA);
+    });
+
+    test('the same package as an asset URL', () {
+      expect(reader.pathToUrl(assetPackageA), packageA);
+    });
+
+    test('another package', () {
+      expect(reader.pathToUrl(packageB), packageB);
+    });
+
+    test('another package as an asset URL', () {
+      expect(reader.pathToUrl(assetPackageB), packageB);
+    });
+
+    test('the same package outside of lib should throw', () {
+      expect(() => reader.pathToUrl(packageATestDir), throwsArgumentError);
+    });
+
+    test('another package outside of lib should throw', () {
+      expect(() => reader.pathToUrl(packageBTestDir), throwsArgumentError);
+    });
+  });
+
+  group('from an asset URL representing a package to', () {
+    setUpAll(() {
+      reader = new LibraryReader(new _FakeLibraryElement(assetPackageA));
+    });
+
+    test('a dart SDK library', () {
+      expect(reader.pathToUrl(dartAsync), dartAsync);
+    });
+
+    test('a dart SDK private library', () {
+      expect(reader.pathToUrl(dartAsyncPrivate), dartAsync);
+    });
+
+    test('the same package', () {
+      expect(reader.pathToUrl(packageA), packageA);
+    });
+
+    test('the same package as an asset URL', () {
+      expect(reader.pathToUrl(assetPackageA), packageA);
+    });
+
+    test('another package', () {
+      expect(reader.pathToUrl(packageB), packageB);
+    });
+
+    test('another package as an asset URL', () {
+      expect(reader.pathToUrl(assetPackageB), packageB);
+    });
+
+    test('the same package outside of lib should throw', () {
+      expect(() => reader.pathToUrl(packageATestDir), throwsArgumentError);
+    });
+
+    test('another package outside of lib should throw', () {
+      expect(() => reader.pathToUrl(packageBTestDir), throwsArgumentError);
+    });
+  });
+
+  group('from an asset URL representing a test directory to', () {
+    setUpAll(() {
+      reader = new LibraryReader(new _FakeLibraryElement(packageATestDir));
+    });
+
+    test('a dart SDK library', () {
+      expect(reader.pathToUrl(dartAsync), dartAsync);
+    });
+
+    test('a dart SDK private library', () {
+      expect(reader.pathToUrl(dartAsyncPrivate), dartAsync);
+    });
+
+    test('the same package', () {
+      expect(reader.pathToUrl(packageA), packageA);
+    });
+
+    test('the same package as an asset URL', () {
+      expect(reader.pathToUrl(assetPackageA), packageA);
+    });
+
+    test('another package', () {
+      expect(reader.pathToUrl(packageB), packageB);
+    });
+
+    test('another package as an asset URL', () {
+      expect(reader.pathToUrl(assetPackageB), packageB);
+    });
+
+    test('the same package in the test directory', () {
+      expect(reader.pathToUrl(packageATestDir), Uri.parse('a.dart'));
+    });
+
+    test('the same package in the test directory, different file', () {
+      expect(reader.pathToUrl(packageATestDirFileB), Uri.parse('b.dart'));
+    });
+
+    test('the same package in the test directory, different deeper file', () {
+      expect(
+        reader.pathToUrl(packageATestDirDeepFile),
+        Uri.parse('in/a/folder/a.dart'),
+      );
+    });
+
+    test('in the same package in the test directory, a shallow file', () {
+      reader = new LibraryReader(
+        new _FakeLibraryElement(packageATestDirDeepFile),
+      );
+      expect(
+        reader.pathToUrl(packageATestDir),
+        Uri.parse('../../../a.dart'),
+      );
+    });
+
+    test('the same package in the tool directory should throw', () {
+      final packageAToolDir = Uri.parse('asset:a/tool/a.dart');
+      expect(() => reader.pathToUrl(packageAToolDir), throwsArgumentError);
+    });
+
+    test('another package in the test directory should throw', () {
+      expect(() => reader.pathToUrl(packageBTestDir), throwsArgumentError);
+    });
+  });
+}
+
+class _FakeLibraryElement implements LibraryElement {
+  final Uri _sourceUri;
+
+  _FakeLibraryElement(this._sourceUri);
+
+  @override
+  noSuchMethod(i) => super.noSuchMethod(i);
+
+  @override
+  Source get source => new _FakeSource(_sourceUri);
+}
+
+class _FakeSource implements Source {
+  @override
+  final Uri uri;
+
+  const _FakeSource(this.uri);
+
+  @override
+  noSuchMethod(i) => super.noSuchMethod(i);
+}


### PR DESCRIPTION
Partial work towards https://github.com/dart-lang/source_gen/issues/293.

I omitted `pathToAsset` and `pathToElement`, because (a) they are just conveniences and (b) this is the bulk of the code for first review - the latter should be quite quick.