### PR TITLE
Remove log.finest from source_gen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.4+1
+
+* Removed a `log.finest` with the output source of each generator. This allows
+  a verbose option (`-v`) for tools like bazel or build_runner to be much more
+  readable and debuggable. Files are emitted to disk for inspection in any
+  case.
+
 ## 0.7.4
 
 * Added `typeNameOf`, which is a safe way to get the name of a `DartType`,

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -224,7 +224,6 @@ Stream<GeneratedOutput> _generate(LibraryElement library,
       var createdUnit = await gen.generate(libraryReader, buildStep);
 
       if (createdUnit != null && createdUnit.isNotEmpty) {
-        log.finest(() => 'Generated $createdUnit for ${buildStep.inputId}');
         yield new GeneratedOutput(gen, createdUnit);
       }
     } catch (e, stack) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.7.4
+version: 0.7.4+1
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
This removes spammy multi-page terminal outputs when a `-v` option is used.

Since the output will almost always make it to disk, this probably isn't useful output.