### PR TITLE
Make pathToUrl working on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.4+2
+
+* Fix file URIs on windows.
+
 ## 0.7.4+1
 
 * Removed a `log.finest` with the output source of each generator. This allows

--- a/lib/src/library.dart
+++ b/lib/src/library.dart
@@ -133,7 +133,7 @@ class LibraryReader {
           // a valid import URL in Dart source code.
           return new Uri(path: to.pathSegments.last);
         }
-        final relative = Uri.parse(p.relative(
+        final relative = p.toUri(p.relative(
           to.toString(),
           from: from.toString(),
         ));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.7.4+1
+version: 0.7.4+2
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
The pathToUrl function in LibraryReader returns an empty Url when the url is an asset on Windows.
This PR aims to fix this issue.