### PR TITLE
Clean up logging pkg:build_runner already logs the input asset ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.8.1
 
+* Cleanup logging output that duplicates headers provided by 
+  `package:build_runner`.
+
 * `InvalidGenerationSourceError` added an optional `element`
   parameter to support more helpful error messages.
 

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -72,7 +72,7 @@ class _Builder extends Builder {
 
   Future _generateForLibrary(
       LibraryElement library, BuildStep buildStep) async {
-    log.fine('Running $_generators for ${buildStep.inputId}');
+    log.fine('Running $runtimeType with ${_generators.length} generator(s).');
     var generatedOutputs =
         await _generate(library, _generators, buildStep).toList();
 
@@ -204,16 +204,17 @@ class LibraryBuilder extends _Builder {
 Stream<GeneratedOutput> _generate(LibraryElement library,
     List<Generator> generators, BuildStep buildStep) async* {
   var libraryReader = new LibraryReader(library);
-  for (var gen in generators) {
+  for (var i = 0; i < generators.length; i++) {
+    var gen = generators[i];
     try {
-      log.finer('Running $gen for ${buildStep.inputId}');
+      log.finer('Running $gen - ${i+1} of ${generators.length}');
       var createdUnit = await gen.generate(libraryReader, buildStep);
 
       if (createdUnit != null && createdUnit.isNotEmpty) {
         yield new GeneratedOutput(gen, createdUnit);
       }
     } catch (e, stack) {
-      log.severe('Error running $gen for ${buildStep.inputId}.', e, stack);
+      log.severe('Error running $gen', e, stack);
       yield new GeneratedOutput.fromError(gen, e, stack);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dev_dependencies:
   build_test: ">0.9.0 <0.11.0"
   collection: ^1.1.2
   cli_util: '>=0.1.0 <0.2.0'
-  logging: ^0.11.3
   test: ^0.12.3
   _test_annotations:
     path: ./_test_annotations

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -6,7 +6,6 @@
 import 'dart:async';
 
 import 'package:build_test/build_test.dart';
-import 'package:logging/logging.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
@@ -191,16 +190,6 @@ void main() {
         });
   });
 
-  test('Error logs contain original input ids', () async {
-    var logs = <LogRecord>[];
-    await testBuilder(new LibraryBuilder(new _ThrowingGenerator()),
-        {'$_pkgName|lib/a.dart': 'void hello() {}'},
-        onLog: logs.add);
-    await new Future(() {});
-    expect(
-        logs.map((l) => l.message), contains(contains('$_pkgName|lib/a.dart')));
-  });
-
   test('Should have a readable toString() message for builders', () {
     final builder = new LibraryBuilder(const _NoOpGenerator());
     expect(builder.toString(), 'Generating .g.dart: NOOP');
@@ -249,11 +238,6 @@ class _BadOutputGenerator extends Generator {
 
   @override
   Future<String> generate(LibraryReader library, _) async => 'not valid code!';
-}
-
-class _ThrowingGenerator extends Generator {
-  @override
-  Future<String> generate(_, __) async => throw new UnimplementedError();
 }
 
 final _customHeader = '// Copyright 1979';


### PR DESCRIPTION
Effectively undoes
https://github.com/dart-lang/source_gen/commit/83ddeb78f8
https://github.com/dart-lang/source_gen/pull/252

From
```
[INFO] Build:Running build...
[FINE] build_cli on test/src/peanut_example.dart:Running [CliGenerator] for build_cli|test/src/peanut_example.dart
[FINE] build_cli on test/src/pubviz_example.dart:Running [CliGenerator] for build_cli|test/src/pubviz_example.dart
[FINER] build_cli on test/src/peanut_example.dart:Running CliGenerator for build_cli|test/src/peanut_example.dart
[FINER] build_cli on test/src/pubviz_example.dart:Running CliGenerator for build_cli|test/src/pubviz_example.dart
[WARNING] build_cli on test/src/peanut_example.dart:
Skipping unassignable fields on `class PeanutOptions`: `coolBean`
[SEVERE] build_cli on test/src/pubviz_example.dart:
Error running CliGenerator for build_cli|test/src/pubviz_example.dart.
Could not parse field `Symbol crazy` - `Symbol` is not supported - yet.
```
To
```
[INFO] Build:Running build...
[FINE] build_cli on test/src/peanut_example.dart:Running PartBuilder with 1 generator(s).
[FINE] build_cli on test/src/pubviz_example.dart:Running PartBuilder with 1 generator(s).
[FINER] build_cli on test/src/peanut_example.dart:Running CliGenerator - 1 of 1
[FINER] build_cli on test/src/pubviz_example.dart:Running CliGenerator - 1 of 1
[WARNING] build_cli on test/src/peanut_example.dart:
Skipping unassignable fields on `class PeanutOptions`: `coolBean`
[SEVERE] build_cli on test/src/pubviz_example.dart:
Error running CliGenerator
Could not parse field `Symbol crazy` - `Symbol` is not supported - yet.
```