### PR TITLE
fix/change: generateForAnnotatedElement now takes 2 args instead of 3

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## 0.9.0
 
-* `GeneratorForAnnotation.generateForAnnotatedElement` now allow multiple return
-  values when implementations return an `Iterable` or `Stream`.
+* `GeneratorForAnnotation`
+  * **BREAKING** `generateForAnnotatedElement` now takes two arguments instead
+    of three: `(AnnotatedElement annotatedElement, BuildStep buildStep)`.
+    `AnnotatedElement` contains the `element` and `annotation` values.
+  * `generateForAnnotatedElement` now allow multiple return values when
+    implementations return an `Iterable` or `Stream`.
   * Values from `generateForAnnotatedElement` have whitespace trimmed. `null`
     and empty values are ignored.
   * Duplicate values are collapsed into a single values. This allows emitting

--- a/source_gen/lib/src/output_helpers.dart
+++ b/source_gen/lib/src/output_helpers.dart
@@ -6,59 +6,34 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 
-/// Runs [run] and converts [Future], [Iterable], and [Stream] implementations
+/// Converts [Future], [Iterable], and [Stream] implementations
 /// containing [String] to a single [Stream] while ensuring all thrown
 /// exceptions are forwarded through the return value.
-Stream<String> normalizeGeneratorOutput(dynamic run()) => StreamCompleter
-    .fromFuture(new Future.sync(run).then(_normalizeGeneratorOutput));
-
-Stream<String> _normalizeGeneratorOutput(Object value) {
-  if (value is String) {
+Stream<String> normalizeGeneratorOutput(Object value) {
+  if (value == null) {
+    return new Stream.empty();
+  } else if (value is Future) {
+    return StreamCompleter.fromFuture(value.then(normalizeGeneratorOutput));
+  } else if (value is String) {
     value = [value];
   }
 
-  value ??= [];
-
   if (value is Iterable) {
-    value = safeIteratorToStream(value as Iterable);
+    value = new Stream.fromIterable(value as Iterable);
   }
 
   if (value is Stream) {
     return value.where((e) => e != null).map((e) {
       if (e is String) {
-        return e;
+        return e.trim();
       }
 
       throw _argError(e);
-    });
+    }).where((e) => e.isNotEmpty);
   }
   throw _argError(value);
 }
 
-/// `Stream.fromIterable` has some weird behavior with errors. See
-/// See https://github.com/dart-lang/sdk/issues/33431
-Stream safeIteratorToStream(Iterable source) {
-  var controller = new StreamController();
-
-  new Future(() {
-    try {
-      var iterator = source.iterator;
-      while (iterator.moveNext()) {
-        controller.add(iterator.current);
-      }
-    } catch (e, stack) {
-      controller.addError(e, stack);
-    } finally {
-      controller.close();
-    }
-  });
-
-  return controller.stream;
-}
-
-ArgumentError _argError(Object value) =>
-    new ArgumentError(badValueErrorMessage(value));
-
-String badValueErrorMessage(Object value) =>
+ArgumentError _argError(Object value) => new ArgumentError(
     'Must be a String or be an Iterable/Stream containing String values. '
-    'Found `${Error.safeToString(value)}` (${value.runtimeType}).';
+    'Found `${Error.safeToString(value)}` (${value.runtimeType}).');

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.9.0
+version: 0.9.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
While we're doing a breaking change, this seems like a nice cleanup
Also dramatically simplified the Stream creation logic
Updated associated tests
Clarified and expanded docs on GeneratorForAnnotation