### PR TITLE
fix(SharedPartBuilder) allow `-` in part Id

### DIFF
--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -275,6 +275,6 @@ const defaultFileHeader = '// GENERATED CODE - DO NOT MODIFY BY HAND';
 
 final _headerLine = '// '.padRight(77, '*');
 
-const partIdRegExpLiteral = r'[A-Za-z_\d]+';
+const partIdRegExpLiteral = r'[A-Za-z_\d-]+';
 
 final _partIdRegExp = new RegExp('^$partIdRegExpLiteral\$');


### PR DESCRIPTION
It's nice when you want to ship more than one generator in a package

For example: json_serializable, json_serializable-literal