### PR TITLE
Reseparate args to generateForAnnotatedElement

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -3,13 +3,9 @@
 * Introduce `SharedPartBuilder` for creating part files that can be merged
   with a new `CombiningBuilder`. Note that `CombiningBuilder` only outputs
   `.g.dart` files.
-* `PartBuilder` now requires a `generatedExtensions` argument. The value should
-  not be `.g.dart`. To produce `.g.dart` files please use the
+* **Breaking** `PartBuilder` now requires a `generatedExtensions` argument. The
+  value should not be `.g.dart`. To produce `.g.dart` files please use the
   `SharedPartBuilder`.
-* `GeneratorForAnnotation`
-  * **BREAKING** `generateForAnnotatedElement` now takes two arguments instead
-    of three: `(AnnotatedElement annotatedElement, BuildStep buildStep)`.
-    `AnnotatedElement` contains the `element` and `annotation` values.
 
 ## 0.8.3
 

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -4,8 +4,10 @@
 
 import 'dart:async';
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 
+import 'constants/reader.dart';
 import 'generator.dart';
 import 'library.dart';
 import 'output_helpers.dart';
@@ -42,8 +44,8 @@ abstract class GeneratorForAnnotation<T> extends Generator {
     var values = new Set<String>();
 
     for (var annotatedElement in library.annotatedWith(typeChecker)) {
-      var generatedValue =
-          generateForAnnotatedElement(annotatedElement, buildStep);
+      var generatedValue = generateForAnnotatedElement(
+          annotatedElement.element, annotatedElement.annotation, buildStep);
       await for (var value in normalizeGeneratorOutput(generatedValue)) {
         assert(value == null || (value.length == value.trim().length));
         values.add(value);
@@ -53,10 +55,10 @@ abstract class GeneratorForAnnotation<T> extends Generator {
     return values.join('\n\n');
   }
 
-  /// Implement to return source code to generate for [annotatedElement].
+  /// Implement to return source code to generate for [element].
   ///
   /// This method is invoked based on finding elements annotated with an
-  /// instance of [T].
+  /// instance of [T]. The [annotation] is provided as a [ConstantReader].
   ///
   /// Supported return values include a single [String] or multiple [String]
   /// instances within an [Iterable] or [Stream]. It is also valid to return a
@@ -65,5 +67,5 @@ abstract class GeneratorForAnnotation<T> extends Generator {
   /// Implementations should return `null` when no content is generated. Empty
   /// or whitespace-only [String] instances are also ignored.
   generateForAnnotatedElement(
-      AnnotatedElement annotatedElement, BuildStep buildStep);
+      Element element, ConstantReader annotation, BuildStep buildStep);
 }

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -5,6 +5,7 @@
 // The first test that runs `testBuilder` takes a LOT longer than the rest.
 @Timeout.factor(3)
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
@@ -78,7 +79,7 @@ class FailingIterableGenerator extends GeneratorForAnnotation<Deprecated> {
 
   @override
   Iterable<String> generateForAnnotatedElement(
-      AnnotatedElement annotatedElement, BuildStep buildStep) sync* {
+      Element element, ConstantReader annotation, BuildStep buildStep) sync* {
     yield '// There are deprecated values in this library!';
     throw new StateError('not supported!');
   }
@@ -92,7 +93,7 @@ class FailingGenerator extends GeneratorForAnnotation<Deprecated> {
 
   @override
   generateForAnnotatedElement(
-      AnnotatedElement annotatedElement, BuildStep buildStep) {
+      Element element, ConstantReader annotation, BuildStep buildStep) {
     throw new StateError('not supported!');
   }
 }
@@ -102,10 +103,10 @@ class RepeatingGenerator extends GeneratorForAnnotation<Deprecated> {
 
   @override
   Iterable<String> generateForAnnotatedElement(
-      AnnotatedElement annotatedElement, BuildStep buildStep) sync* {
+      Element element, ConstantReader annotation, BuildStep buildStep) sync* {
     yield '// There are deprecated values in this library!';
 
-    yield '// ${annotatedElement.element}';
+    yield '// $element';
   }
 }
 
@@ -116,7 +117,7 @@ class LiteralOutput<T> extends GeneratorForAnnotation<Deprecated> {
 
   @override
   T generateForAnnotatedElement(
-          AnnotatedElement annotatedElement, BuildStep buildStep) =>
+          Element element, ConstantReader annotation, BuildStep buildStep) =>
       null;
 }
 


### PR DESCRIPTION
Partial revert of 8f37134fd7a8d983778d79cbdbd313f40df1c7f6

While migrating usages it became apparent that repeatedly needing to
dereference `annotatedElement` is annoying.