### PR TITLE
Add cleanup of .g.part files

### DIFF
--- a/source_gen/build.yaml
+++ b/source_gen/build.yaml
@@ -6,7 +6,7 @@ builders:
     build_extensions: {".dart": [".g.dart"]}
     auto_apply: none
     build_to: source
-    required_inputs: ['.g.part']
+    required_inputs: [".g.part"]
     applies_builders: ["source_gen|part_cleanup"]
 post_process_builders:
   part_cleanup:

--- a/source_gen/build.yaml
+++ b/source_gen/build.yaml
@@ -12,6 +12,3 @@ post_process_builders:
   part_cleanup:
     import: "package:source_gen/builder.dart"
     builder_factory: "partCleanup"
-    defaults:
-      options:
-        enabled: true

--- a/source_gen/build.yaml
+++ b/source_gen/build.yaml
@@ -7,3 +7,11 @@ builders:
     auto_apply: none
     build_to: source
     required_inputs: ['.g.part']
+    applies_builders: ["source_gen|part_cleanup"]
+post_process_builders:
+  part_cleanup:
+    import: "package:source_gen/builder.dart"
+    builder_factory: "partCleanup"
+    defaults:
+      options:
+        enabled: true

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -40,7 +40,7 @@ Builder combiningBuilder([BuilderOptions options]) {
 }
 
 PostProcessBuilder partCleanup(BuilderOptions options) =>
-    const FileDeletingBuilder(const ['.g.dart']);
+    const FileDeletingBuilder(const ['.g.part']);
 
 /// A [Builder] which combines part files generated from [SharedPartBuilder].
 ///

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -39,6 +39,9 @@ Builder combiningBuilder([BuilderOptions options]) {
   return builder;
 }
 
+PostProcessBuilder partCleanup(BuilderOptions options) =>
+    const FileDeletingBuilder(const ['.g.dart']);
+
 /// A [Builder] which combines part files generated from [SharedPartBuilder].
 ///
 /// This will glob all files of the form `.*.g.part`.

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   analyzer: '>=0.31.0 <0.33.0'
   async: ^2.0.7
-  build: '>=0.10.0 <0.13.0'
+  build: ^0.12.4
   dart_style: '>=0.1.7 <2.0.0'
   meta: ^1.1.0
   path: ^1.3.2


### PR DESCRIPTION
Towards #319

These never need to be served or included in the merged output directory
so they should always be cleaned by the post process builder.