### PR TITLE
misc: add SDK constraint to _test_annotation package

### DIFF
--- a/_test_annotations/pubspec.yaml
+++ b/_test_annotations/pubspec.yaml
@@ -1,1 +1,3 @@
 name: _test_annotations
+environment:
+  sdk: '>=2.0.0-dev.19.0 <3.0.0'


### PR DESCRIPTION
Dart 2 treats packages without an SDK constraint as <2.0.0