### PR TITLE
Fix readme typo

### DIFF
--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -87,7 +87,7 @@ builders:
     import: "package:this_package/builder.dart"
     builder_factories: ["someCoolBuilder"]
     # The `partId` argument to `SharedPartBuilder` is "some_cool_builder"
-    build_exceptions: {".dart": [".some_cool_buidler.g.part"]}
+    build_extensions: {".dart": [".some_cool_buidler.g.part"]}
     auto_apply: dependents
     build_to: cache
     # To copy the `.g.part` content into `.g.dart` in the source tree


### PR DESCRIPTION
Hello,


I found an error in the `build.yaml` configuration example in the README. Here's a quick fix