### PR TITLE
Remove some analyzer ast and src imports

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2
+
+* Avoid using the AST analyzer model from `LibraryReader`.
+
 ## 0.9.1+3
 
 * Support the latest `pkg:analyzer`.

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,12 +1,12 @@
 name: source_gen
-version: 0.9.1+3
+version: 0.9.2-dev
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen
 environment:
   sdk: '>=2.0.0-dev.64.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.31.0 <0.34.0'
+  analyzer: ^0.33.0
   async: ^2.0.7
   build: ">=0.12.4 <2.0.0"
   dart_style: '>=0.1.7 <2.0.0'

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen
 environment:
-  sdk: '>=2.0.0-dev.64.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 dependencies:
   analyzer: ^0.33.0
   async: ^2.0.7


### PR DESCRIPTION
- Use `LibraryElement.exportNamespace` to find types across a libraries
entire visible surface area rather than referencing a
`NamespaceBuilder`.
- Use the different getters for element typs from
`CompilationUnitElement` to get all members of a library rather than
getting the declarations from a `CompilationUnit`.
- Increase minimum anlayzer version to ensure that the `mixins` getter
is available.