### PR TITLE
Add LibraryReader.enums

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.3
 
-* Rename `LibraryReader.classElemetns` to `LibraryReader.classes` to better
+* Rename `LibraryReader.classElements` to `LibraryReader.classes` to better
   reflect the behavior. Deprecate the old name.
 * Add `LibraryReader.enums`.
 

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.3
+
+* Rename `LibraryReader.classElemetns` to `LibraryReader.classes` to better
+  reflect the behavior. Deprecate the old name.
+* Add `LibraryReader.enums`.
+
 ## 0.9.2
 
 * Avoid using the AST analyzer model from `LibraryReader`.

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -167,6 +167,6 @@ class LibraryReader {
   @Deprecated('Use classes instead')
   Iterable<ClassElement> get classElements => classes;
 
-  /// All of the elemetns representing enums in this library.
+  /// All of the elements representing enums in this library.
   Iterable<ClassElement> get enums => element.units.expand((cu) => cu.enums);
 }

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -161,7 +161,12 @@ class LibraryReader {
         fromSegments[1] == toSegments[1];
   }
 
-  /// All of the `class` elements in this library.
-  Iterable<ClassElement> get classElements =>
-      element.units.expand((cu) => cu.types);
+  /// All of the elements reperesenting classes in this library.
+  Iterable<ClassElement> get classes => element.units.expand((cu) => cu.types);
+
+  @Deprecated('Use classes instead')
+  Iterable<ClassElement> get classElements => classes;
+
+  /// All of the elemetns representing enums in this library.
+  Iterable<ClassElement> get enums => element.units.expand((cu) => cu.enums);
 }

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.9.2
+version: 0.9.3
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen

--- a/source_gen/test/library/find_type_test.dart
+++ b/source_gen/test/library/find_type_test.dart
@@ -15,14 +15,17 @@ final _source = r'''
   import 'dart:async' show Stream;
 
   part 'part.dart';
-  
+
   class Example {}
+  enum Enum{A,B}
 ''';
 
 final _partSource = r'''
 part of 'source.dart';
 
 class PartClass {}
+
+enum PartEnum{A,B}
 ''';
 
 void main() {
@@ -36,7 +39,12 @@ void main() {
   });
 
   test('class count', () {
+    expect(library.classes.map((c) => c.name), ['Example', 'PartClass']);
     expect(library.classElements, hasLength(2));
+  });
+
+  test('enum count', () {
+    expect(library.enums.map((e) => e.name), ['Enum', 'PartEnum']);
   });
 
   test('should return a type not exported', () {

--- a/source_gen/test/library/find_type_test.dart
+++ b/source_gen/test/library/find_type_test.dart
@@ -41,7 +41,7 @@ void main() {
   test('class count', () {
     expect(library.classes.map((c) => c.name), ['Example', 'PartClass']);
     // ignore: deprecated_member_use
-    expect(library.classElements, hasLength(2));
+    expect(library.classElements, orderedEquals(library.classes));
   });
 
   test('enum count', () {

--- a/source_gen/test/library/find_type_test.dart
+++ b/source_gen/test/library/find_type_test.dart
@@ -40,6 +40,7 @@ void main() {
 
   test('class count', () {
     expect(library.classes.map((c) => c.name), ['Example', 'PartClass']);
+    // ignore: deprecated_member_use
     expect(library.classElements, hasLength(2));
   });
 


### PR DESCRIPTION
Fixes #388

Deprecate the `classElements` getter since it is ambiguous, both classes
and enums are represented by `ClassElement` in analyzer, but we don't
want to exclusively always mix them in this interface. Add the name
`classes` to be more specific. Add an implementation for `enums.`