### PR TITLE
Use ParsedLibraryImpl to find source span

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.4
+
+* Use `ParsedLibraryResult` to find source spans for unresolvable annotations.
+
 ## 0.9.3
 
 * Rename `LibraryReader.classElements` to `LibraryReader.classes` to better

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.9.3
+version: 0.9.4
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
The old code path does not work when the ElementAnnotation was returned
by an `AnalysisDriver` instead `AnalysisContext`. Prepare for
`build_resolvers` to switch to `AnalysisDriver` by migrating to a
forwards compatible approach.