### PR TITLE
Migrate off ParsedLibraryResultImpl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,68 +1,68 @@
-# Created with package:mono_repo v1.2.1
+# Created with package:mono_repo v2.0.0
 language: dart
 
 jobs:
   include:
     - stage: analyze_format
-      name: "SDK: dev - DIR: _test_annotations - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
-      script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="_test_annotations"
+      name: "SDK: dev; PKG: _test_annotations; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
-    - stage: analyze_format
-      name: "SDK: dev - DIR: example - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
+      env: PKGS="_test_annotations"
       script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="example"
+    - stage: analyze_format
+      name: "SDK: dev; PKG: example; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
-    - stage: analyze_format
-      name: "SDK: stable - DIR: example - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
+      env: PKGS="example"
       script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="example"
+    - stage: analyze_format
+      name: "SDK: dev; PKG: example_usage; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: dev
+      env: PKGS="example_usage"
+      script: ./tool/travis.sh dartfmt dartanalyzer
+    - stage: analyze_format
+      name: "SDK: dev; PKG: source_gen; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: dev
+      env: PKGS="source_gen"
+      script: ./tool/travis.sh dartfmt dartanalyzer
+    - stage: analyze_format
+      name: "SDK: stable; PKG: example; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: stable
-    - stage: analyze_format
-      name: "SDK: 2.0.0 - DIR: example - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
+      env: PKGS="example"
       script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="example"
+    - stage: analyze_format
+      name: "SDK: 2.0.0; PKG: example; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: "2.0.0"
-    - stage: analyze_format
-      name: "SDK: dev - DIR: example_usage - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
+      env: PKGS="example"
       script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="example_usage"
-      dart: dev
     - stage: analyze_format
-      name: "SDK: 2.1.0 - DIR: example_usage - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
-      script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="example_usage"
+      name: "SDK: 2.1.0; PKG: example_usage; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: "2.1.0"
-    - stage: unit_test
-      name: "SDK: dev - DIR: example_usage - TASKS: pub run test --run-skipped"
-      script: ./tool/travis.sh test
-      env: PKG="example_usage"
-      dart: dev
-    - stage: unit_test
-      name: "SDK: 2.1.0 - DIR: example_usage - TASKS: pub run test --run-skipped"
-      script: ./tool/travis.sh test
-      env: PKG="example_usage"
+      env: PKGS="example_usage"
+      script: ./tool/travis.sh dartfmt dartanalyzer
+    - stage: analyze_format
+      name: "SDK: 2.1.0; PKG: source_gen; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: "2.1.0"
-    - stage: analyze_format
-      name: "SDK: dev - DIR: source_gen - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
+      env: PKGS="source_gen"
       script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="source_gen"
-      dart: dev
-    - stage: analyze_format
-      name: "SDK: 2.0.0 - DIR: source_gen - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
-      script: ./tool/travis.sh dartfmt dartanalyzer
-      env: PKG="source_gen"
-      dart: "2.0.0"
     - stage: unit_test
-      name: "SDK: dev - DIR: source_gen - TASKS: pub run build_runner test -- -j 1"
-      script: ./tool/travis.sh command
-      env: PKG="source_gen"
+      name: "SDK: dev; PKG: example_usage; TASKS: `pub run test --run-skipped`"
       dart: dev
+      env: PKGS="example_usage"
+      script: ./tool/travis.sh test
     - stage: unit_test
-      name: "SDK: 2.0.0 - DIR: source_gen - TASKS: pub run build_runner test -- -j 1"
+      name: "SDK: 2.1.0; PKG: example_usage; TASKS: `pub run test --run-skipped`"
+      dart: "2.1.0"
+      env: PKGS="example_usage"
+      script: ./tool/travis.sh test
+    - stage: unit_test
+      name: "SDK: dev; PKG: source_gen; TASKS: `pub run build_runner test -- -j 1`"
+      dart: dev
+      env: PKGS="source_gen"
       script: ./tool/travis.sh command
-      env: PKG="source_gen"
-      dart: "2.0.0"
+    - stage: unit_test
+      name: "SDK: 2.1.0; PKG: source_gen; TASKS: `pub run build_runner test -- -j 1`"
+      dart: "2.1.0"
+      env: PKGS="source_gen"
+      script: ./tool/travis.sh command
 
 stages:
   - analyze_format

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,8 @@ jobs:
       env: PKGS="source_gen"
       script: ./tool/travis.sh dartfmt dartanalyzer
     - stage: analyze_format
-      name: "SDK: stable; PKG: example; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
-      dart: stable
-      env: PKGS="example"
-      script: ./tool/travis.sh dartfmt dartanalyzer
-    - stage: analyze_format
-      name: "SDK: 2.0.0; PKG: example; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
-      dart: "2.0.0"
+      name: "SDK: 2.1.0; PKG: example; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: "2.1.0"
       env: PKGS="example"
       script: ./tool/travis.sh dartfmt dartanalyzer
     - stage: analyze_format

--- a/example/mono_pkg.yaml
+++ b/example/mono_pkg.yaml
@@ -1,8 +1,7 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
   - dev
-  - stable
-  - 2.0.0
+  - 2.1.0
 
 stages:
   - analyze_format:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: source_gen_example
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   build: ^1.0.0

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.4+2
+
+* Internal cleanup.
+
 ## 0.9.4+1
 
 * Support the latest `pkg:analyzer`.

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:pedantic/pedantic.dart';
 
 import 'generated_output.dart';
 import 'generator.dart';
@@ -141,8 +142,7 @@ class _Builder extends Builder {
           stack);
     }
 
-    // ignore: unawaited_futures
-    buildStep.writeAsString(outputId, genPartContent);
+    unawaited(buildStep.writeAsString(outputId, genPartContent));
   }
 
   @override

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -5,8 +5,6 @@
 import 'dart:mirrors' hide SourceLocation;
 
 import 'package:analyzer/dart/ast/ast.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/analysis/results.dart';
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -291,14 +289,12 @@ class UnresolvedAnnotationException implements Exception {
   /// May be `null` if the import library was not found.
   final SourceSpan annotationSource;
 
-  // TODO: Remove internal API once AnalysisDriver / AnalysisSession only.
-  // https://github.com/dart-lang/sdk/issues/32454
-  static SourceSpan _getSourceSpanFrom(
+  static SourceSpan _findSpan(
     Element annotatedElement,
     int annotationIndex,
   ) {
-    // ignore: deprecated_member_use
-    final parsedLibrary = ParsedLibraryResultImpl.tmp(annotatedElement.library);
+    final parsedLibrary = annotatedElement.session
+        .getParsedLibraryByElement(annotatedElement.library);
     final declaration = parsedLibrary.getElementDeclaration(annotatedElement);
     final annotatedNode = declaration.node as AnnotatedNode;
     final annotation = annotatedNode.metadata[annotationIndex];
@@ -317,7 +313,7 @@ class UnresolvedAnnotationException implements Exception {
     Element annotatedElement,
     int annotationIndex,
   ) {
-    final sourceSpan = _getSourceSpanFrom(annotatedElement, annotationIndex);
+    final sourceSpan = _findSpan(annotatedElement, annotationIndex);
     return UnresolvedAnnotationException._(annotatedElement, sourceSpan);
   }
 

--- a/source_gen/mono_pkg.yaml
+++ b/source_gen/mono_pkg.yaml
@@ -1,7 +1,7 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
   - dev
-  - 2.0.0
+  - 2.1.0
 
 stages:
   - analyze_format:

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -5,7 +5,7 @@ description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   analyzer: ^0.35.0

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,25 +1,26 @@
 name: source_gen
-version: 0.9.5-dev
+version: 0.9.4+2
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.33.3 <0.36.0'
+  analyzer: ^0.35.0
   async: ^2.0.7
-  build: '>=0.12.4 <2.0.0'
-  dart_style: '>=0.1.7 <2.0.0'
+  build: ^1.0.0
+  dart_style: ^1.0.0
   glob: ^1.1.0
   meta: ^1.1.0
   path: ^1.3.2
+  pedantic: ^1.0.0
   source_span: ^1.4.0
 
 dev_dependencies:
   build_runner: ^1.0.0
-  build_test: ">0.9.0 <0.11.0"
+  build_test: ^0.10.0
   build_vm_compilers: ^0.1.1
   test: ^1.0.0
   _test_annotations:

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,50 +1,52 @@
 #!/bin/bash
-# Created with package:mono_repo v1.2.1
+# Created with package:mono_repo v2.0.0
 
-if [ -z "$PKG" ]; then
-  echo -e '\033[31mPKG environment variable must be set!\033[0m'
+if [[ -z ${PKGS} ]]; then
+  echo -e '\033[31mPKGS environment variable must be set!\033[0m'
   exit 1
 fi
 
-if [ "$#" == "0" ]; then
+if [[ "$#" == "0" ]]; then
   echo -e '\033[31mAt least one task argument must be provided!\033[0m'
   exit 1
 fi
 
-pushd $PKG
-pub upgrade || exit $?
-
 EXIT_CODE=0
 
-while (( "$#" )); do
-  TASK=$1
-  case $TASK in
-  command) echo
-    echo -e '\033[1mTASK: command\033[22m'
-    echo -e 'pub run build_runner test -- -j 1'
-    pub run build_runner test -- -j 1 || EXIT_CODE=$?
-    ;;
-  dartanalyzer) echo
-    echo -e '\033[1mTASK: dartanalyzer\033[22m'
-    echo -e 'dartanalyzer --fatal-infos --fatal-warnings .'
-    dartanalyzer --fatal-infos --fatal-warnings . || EXIT_CODE=$?
-    ;;
-  dartfmt) echo
-    echo -e '\033[1mTASK: dartfmt\033[22m'
-    echo -e 'dartfmt -n --set-exit-if-changed .'
-    dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
-    ;;
-  test) echo
-    echo -e '\033[1mTASK: test\033[22m'
-    echo -e 'pub run test --run-skipped'
-    pub run test --run-skipped || EXIT_CODE=$?
-    ;;
-  *) echo -e "\033[31mNot expecting TASK '${TASK}'. Error!\033[0m"
-    EXIT_CODE=1
-    ;;
-  esac
+for PKG in ${PKGS}; do
+  echo -e "\033[1mPKG: ${PKG}\033[22m"
+  pushd "${PKG}" || exit $?
+  pub upgrade --no-precompile || exit $?
 
-  shift
+  for TASK in "$@"; do
+    case ${TASK} in
+    command) echo
+      echo -e '\033[1mTASK: command\033[22m'
+      echo -e 'pub run build_runner test -- -j 1'
+      pub run build_runner test -- -j 1 || EXIT_CODE=$?
+      ;;
+    dartanalyzer) echo
+      echo -e '\033[1mTASK: dartanalyzer\033[22m'
+      echo -e 'dartanalyzer --fatal-infos --fatal-warnings .'
+      dartanalyzer --fatal-infos --fatal-warnings . || EXIT_CODE=$?
+      ;;
+    dartfmt) echo
+      echo -e '\033[1mTASK: dartfmt\033[22m'
+      echo -e 'dartfmt -n --set-exit-if-changed .'
+      dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
+      ;;
+    test) echo
+      echo -e '\033[1mTASK: test\033[22m'
+      echo -e 'pub run test --run-skipped'
+      pub run test --run-skipped || EXIT_CODE=$?
+      ;;
+    *) echo -e "\033[31mNot expecting TASK '${TASK}'. Error!\033[0m"
+      EXIT_CODE=1
+      ;;
+    esac
+  done
+
+  popd
 done
 
-exit $EXIT_CODE
+exit ${EXIT_CODE}


### PR DESCRIPTION
This was a transition API until we could know that `element.session`
would be available. With analyzer above version `0.35.0` we know that
`build_resolvers` will be using a code path that makes `.session`
available.

Also:
- Remove unnecessarily low minimum dependency versions for packages that
  we would not be able to solve with due to the analyzer constraint.
- Replace an `// ignore: unawaited_futures` with `unawaited` call from
  `package:pedantic`.
- Remove comment referencing closed SDK issue. GOing through the
  `AnnotatedNode` is the correct approach for finding source ranges.
- Rename method to avoid a prefix of `get`.