### PR TITLE
Remove redundant header from readme

### DIFF
--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -1,5 +1,3 @@
-# source_gen
-
 <p align="center">
   <a href="https://travis-ci.org/dart-lang/source_gen">
     <img src="https://travis-ci.org/dart-lang/source_gen.svg?branch=master" alt="Build Status" />


### PR DESCRIPTION
in all places where this is displayed, it's already pretty obvious