### PR TITLE
Don't use DartType.toString()

### DIFF
--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -42,11 +42,11 @@ void main() {
 
 // There are deprecated values in this library!
 
-// String foo
+// foo
 
-// String bar
+// bar
 
-// String baz
+// baz
 '''
     });
   });
@@ -106,7 +106,7 @@ class RepeatingGenerator extends GeneratorForAnnotation<Deprecated> {
       Element element, ConstantReader annotation, BuildStep buildStep) sync* {
     yield '// There are deprecated values in this library!';
 
-    yield '// $element';
+    yield '// ${element.name}';
   }
 }
 

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -17,16 +17,16 @@ import 'package:test/test.dart';
 void main() {
   // Resolved top-level types from dart:core and dart:collection.
   InterfaceType staticUri;
-  DartType staticMap;
-  DartType staticHashMap;
-  DartType staticUnmodifiableListView;
+  InterfaceType staticMap;
+  InterfaceType staticHashMap;
+  InterfaceType staticUnmodifiableListView;
   TypeChecker staticIterableChecker;
   TypeChecker staticMapChecker;
   TypeChecker staticHashMapChecker;
 
   // Resolved top-level types from package:source_gen.
-  DartType staticGenerator;
-  DartType staticGeneratorForAnnotation;
+  InterfaceType staticGenerator;
+  InterfaceType staticGeneratorForAnnotation;
   TypeChecker staticGeneratorChecker;
   TypeChecker staticGeneratorForAnnotationChecker;
 
@@ -81,7 +81,7 @@ void main() {
     group('(Map)', () {
       test('should equal dart:core#Map', () {
         expect(checkMap().isExactlyType(staticMap), isTrue,
-            reason: '${checkMap()} != $staticMap');
+            reason: '${checkMap()} != ${staticMap.element.name}');
       });
 
       test('should not be a super type of dart:core#Map', () {
@@ -130,27 +130,28 @@ void main() {
     group('(Generator)', () {
       test('should equal Generator', () {
         expect(checkGenerator().isExactlyType(staticGenerator), isTrue,
-            reason: '${checkGenerator()} != $staticGenerator');
+            reason: '${checkGenerator()} != ${staticGenerator.element.name}');
       });
 
       test('should not be a super type of Generator', () {
         expect(checkGenerator().isSuperTypeOf(staticGenerator), isFalse,
-            reason: '${checkGenerator()} is super of $staticGenerator');
+            reason: '${checkGenerator()} is super of '
+                '${staticGenerator.element.name}');
       });
 
       test('should be a super type of GeneratorForAnnotation', () {
         expect(checkGenerator().isSuperTypeOf(staticGeneratorForAnnotation),
             isTrue,
-            reason:
-                '${checkGenerator()} is not super of $staticGeneratorForAnnotation');
+            reason: '${checkGenerator()} is not super of '
+                '${staticGeneratorForAnnotation.element.name}');
       });
 
       test('should be assignable from GeneratorForAnnotation', () {
         expect(
             checkGenerator().isAssignableFromType(staticGeneratorForAnnotation),
             isTrue,
-            reason:
-                '${checkGenerator()} is not assignable from $staticGeneratorForAnnotation');
+            reason: '${checkGenerator()} is not assignable from '
+                '${staticGeneratorForAnnotation.element.name}');
       });
     });
   }


### PR DESCRIPTION
We would like to change `DartType.toString()` to include nullability suffixes.

It is not used much in this package, but it is still used in string comparisons and changes to `analyzer` will break these tests.