### PR TITLE
Log more carefully.

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.4+7
+
+* Fix an exception during error reporting when the `Element` reported is in
+  a summary file rather than a source file.
+
 ## 0.9.4+6
 
 * Allow `package:analyzer` version `0.39.x`.

--- a/source_gen/lib/src/generator.dart
+++ b/source_gen/lib/src/generator.dart
@@ -58,10 +58,9 @@ class InvalidGenerationSourceError extends Error {
           ..writeln(span.start.toolString)
           ..write(span.highlight());
       } catch (_) {
-        buffer
-          ..writeln()
-          ..writeln('While logging this error: '
-              'tried to log source from "$element" but couldn\'t find it.');
+        // Source for `element` wasn't found, it must be in a summary with no
+        // associated source. We can still give the name.
+        buffer..writeln()..writeln('Cause: $element');
       }
     }
 

--- a/source_gen/lib/src/generator.dart
+++ b/source_gen/lib/src/generator.dart
@@ -51,11 +51,18 @@ class InvalidGenerationSourceError extends Error {
     final buffer = StringBuffer(message);
 
     if (element != null) {
-      final span = spanForElement(element);
-      buffer
-        ..writeln()
-        ..writeln(span.start.toolString)
-        ..write(span.highlight());
+      try {
+        final span = spanForElement(element);
+        buffer
+          ..writeln()
+          ..writeln(span.start.toolString)
+          ..write(span.highlight());
+      } catch (_) {
+        buffer
+          ..writeln()
+          ..writeln('While logging this error: '
+              'tried to log source from "$element" but couldn\'t find it.');
+      }
     }
 
     return buffer.toString();

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.9.4+7-dev
+version: 0.9.4+7
 author: Dart Team <misc@dartlang.org>
 description: Automated source code generation for Dart.
 homepage: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
If analysis is being done using a combination of srcs + summaries, and the element specified is in a summary, then we won't be able to find the src to log it.

Currently this causes an uncaught exception :)

A simple try/catch improves matters.