### PR TITLE
Add support for an `ignore_for_file` option to `combining_builder`.

### DIFF
--- a/example_usage/build.yaml
+++ b/example_usage/build.yaml
@@ -14,3 +14,10 @@ targets:
       source_gen_example|property_product:
         generate_for:
           - lib/*.dart
+      # The end-user of a builder which applies "source_gen|combining_builder"
+      # may configure the builder to ignore specific lints for their project
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+          - lint_a
+          - lint_b

--- a/example_usage/lib/library_source.g.dart
+++ b/example_usage/lib/library_source.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: lint_a, lint_b
+
 part of 'library_source.dart';
 
 // **************************************************************************

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.9.5-dev
 
+* Add support for an `ignore_for_file` option to `combining_builder`.
+
 * Expand documentation for `GeneratorForAnnotation` to make it clear that it
   only targets elements at the top level of a library.
 

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -93,6 +93,30 @@ builders:
     applies_builders: ["source_gen|combining_builder"]
 ```
 
+### Configuring `combining_builder` `ignore_for_file`
+
+Sometimes generated code does not support all of the
+[lints](https://dart-lang.github.io/linter/) specified in the target package.
+When using a `Builder` based on `package:source_gen` which applies
+`combining_builder`, set the `ignore_for_file` option to a list of lints you
+wish to be ignored in all generated libraries.
+
+_Example `build.yaml` configuration:_
+
+```yaml
+targets:
+  $default":
+    builders:
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+          - lint_alpha
+          - lint_beta
+```
+
+If you provide a builder that uses `SharedPartBuilder` and `combining_builder`,
+you should document this feature for your users.
+
 ## FAQ
 
 ### What is the difference between `source_gen` and [build][]?

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -388,6 +388,33 @@ void main() {
             '// Part: a.only_whitespace.g.part\n\n')),
       });
     });
+
+    test('includes ignore for file if enabled', () async {
+      await testBuilder(
+        const CombiningBuilder(ignoreForFile: {
+          'lines_longer_than_80_chars',
+          'prefer_expression_function_bodies',
+        }),
+        {
+          '$_pkgName|lib/a.dart': 'library a; part "a.g.dart";',
+          '$_pkgName|lib/a.foo.g.part': '\n\nfoo generated content\n',
+          '$_pkgName|lib/a.only_whitespace.g.part': '\n\n\t  \n \n',
+          '$_pkgName|lib/a.bar.g.part': '\nbar generated content',
+        },
+        generateFor: {'$_pkgName|lib/a.dart'},
+        outputs: {
+          '$_pkgName|lib/a.g.dart': decodedMatches(endsWith(r'''
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
+part of a;
+
+bar generated content
+
+foo generated content
+''')),
+        },
+      );
+    });
   });
 
   test('can skip formatting with a trivial lambda', () async {


### PR DESCRIPTION
Related to https://github.com/dart-lang/source_gen/issues/370
Closes https://github.com/dart-lang/json_serializable/pull/604
Fixes https://github.com/dart-lang/json_serializable/issues/557