### PR TITLE
Handle new warning from build system

### DIFF
--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -476,12 +476,24 @@ Future _generateTest(CommentGenerator gen, String expectedContent) async {
   final srcs = _createPackageStub();
   final builder = PartBuilder([gen], '.foo.dart');
 
-  await testBuilder(builder, srcs,
-      generateFor: {'$_pkgName|lib/test_lib.dart'},
-      outputs: {
-        '$_pkgName|lib/test_lib.foo.dart': decodedMatches(expectedContent),
-      },
-      onLog: (log) => fail('Unexpected log message: ${log.message}'));
+  await testBuilder(
+    builder,
+    srcs,
+    generateFor: {'$_pkgName|lib/test_lib.dart'},
+    outputs: {
+      '$_pkgName|lib/test_lib.foo.dart': decodedMatches(expectedContent),
+    },
+    onLog: (log) {
+      if (log.message.contains(
+        'Your current `analyzer` version may not fully support your current '
+        'SDK version.',
+      )) {
+        // This may happen with pre-release SDKs. Not an error.
+        return;
+      }
+      fail('Unexpected log message: ${log.message}');
+    },
+  );
 }
 
 Map<String, String> _createPackageStub(


### PR DESCRIPTION
A warning is emitted in `build_resolvers`>= 1.3.7 that does not indicate failure.

Handle this case in tests.

See https://github.com/dart-lang/build/commit/aede119300880c268f661fa5b1380b1a3e060bb6