### PR TITLE
Optimize annotation generators to not resolve libs with no annotations

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.10
+
+* Optimize for the case where we have only GeneratorForAnnotation generators,
+  and we know there are no annotations present in the file at all.
+
 ## 0.9.9
 
 * Allow `package:analyzer` version `0.41.x`.

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -74,7 +74,7 @@ class _Builder extends Builder {
     if (!await resolver.isLibrary(buildStep.inputId)) return;
 
     if (_generators.every((g) => g is GeneratorForAnnotation) &&
-        !await _hasAnyTopLevelAnnotations(buildStep.inputId, resolver)) {
+        !(await _hasAnyTopLevelAnnotations(buildStep.inputId, resolver))) {
       return;
     }
 
@@ -345,12 +345,11 @@ Stream<GeneratedOutput> _generate(
 Future<bool> _hasAnyTopLevelAnnotations(
     AssetId input, Resolver resolver) async {
   final parsed = await resolver.compilationUnitFor(input);
-  final annotatableObjects = [
-    ...parsed.directives,
-    ...parsed.declarations,
-  ];
-  for (var object in annotatableObjects) {
-    if (object.metadata.isNotEmpty) return true;
+  for (var directive in parsed.directives) {
+    if (directive.metadata.isNotEmpty) return true;
+  }
+  for (var declaration in parsed.declarations) {
+    if (declaration.metadata.isNotEmpty) return true;
   }
   return false;
 }

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:pedantic/pedantic.dart';
-import 'package:source_gen/source_gen.dart';
 
 import 'generated_output.dart';
 import 'generator.dart';
+import 'generator_for_annotation.dart';
 import 'library.dart';
 import 'utils.dart';
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.9.9
+version: 0.9.10
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -4,10 +4,10 @@
 
 import 'dart:convert';
 
+@TestOn('vm')
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
-@TestOn('vm')
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/builder.dart';

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
 import 'dart:convert';
 
-@TestOn('vm')
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -546,7 +546,8 @@ foo generated content
         'Generating .foo.dart: _LiteralGenerator, _LiteralGenerator');
   });
 
-  test('Does not resolve the library if it doesn\'t need to', () async {
+  test('Does not resolve the library if there are no top level annotations',
+      () async {
     final builder = LibraryBuilder(const _DeprecatedGenerator());
     final input = AssetId('a', 'lib/a.dart');
     final buildStep = _TestingBuildStep(input, {

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -2,6 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
 @TestOn('vm')
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
@@ -540,6 +545,17 @@ foo generated content
     expect(builders.toString(),
         'Generating .foo.dart: _LiteralGenerator, _LiteralGenerator');
   });
+
+  test('Does not resolve the library if it doesn\'t need to', () async {
+    final builder = LibraryBuilder(const _DeprecatedGenerator());
+    final input = AssetId('a', 'lib/a.dart');
+    final buildStep = _TestingBuildStep(input, {
+      input: 'main() {}',
+    });
+    await builder.build(buildStep);
+    expect(buildStep.resolver.parsedUnits, {input});
+    expect(buildStep.resolver.resolvedLibs, isEmpty);
+  });
 }
 
 Future _generateTest(CommentGenerator gen, String expectedContent) async {
@@ -593,6 +609,69 @@ class _BadOutputGenerator extends Generator {
 
   @override
   String generate(_, __) => 'not valid code!';
+}
+
+class _DeprecatedGenerator extends GeneratorForAnnotation<Deprecated> {
+  const _DeprecatedGenerator();
+
+  @override
+  void generateForAnnotatedElement(
+          Element element, ConstantReader annotation, BuildStep buildStep) =>
+      throw UnimplementedError();
+}
+
+class _TestingBuildStep implements BuildStep {
+  @override
+  final AssetId inputId;
+
+  @override
+  final _TestingResolver resolver;
+
+  final Map<AssetId, String> assets;
+
+  _TestingBuildStep(this.inputId, this.assets)
+      : resolver = _TestingResolver(assets);
+
+  @override
+  Future<bool> canRead(AssetId id) async => assets.containsKey(id);
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding}) async =>
+      assets[id];
+
+  @override
+  void noSuchMethod(_) => throw UnimplementedError();
+}
+
+class _TestingResolver implements Resolver {
+  final Map<AssetId, String> assets;
+  final parsedUnits = <AssetId>{};
+  final resolvedLibs = <AssetId>{};
+
+  _TestingResolver(this.assets);
+
+  @override
+  Future<CompilationUnit> compilationUnitFor(AssetId assetId,
+      {bool allowSyntaxErrors = false}) async {
+    parsedUnits.add(assetId);
+    return parseString(content: assets[assetId]).unit;
+  }
+
+  @override
+  Future<bool> isLibrary(AssetId assetId) async {
+    final unit = await compilationUnitFor(assetId);
+    return unit.directives.every((d) => d is! PartOfDirective);
+  }
+
+  @override
+  Future<LibraryElement> libraryFor(AssetId assetId,
+      {bool allowSyntaxErrors = false}) async {
+    resolvedLibs.add(assetId);
+    return null;
+  }
+
+  @override
+  void noSuchMethod(_) => throw UnimplementedError();
 }
 
 const _customHeader = '// Copyright 1979';


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_gen/issues/481 (or as well as I can close that without major breaking changes).

In the case where we have nothing but GeneratorForAnnotation generators, get the compilation unit for the library and if there are zero top level annotations then bail out early.