### PR TITLE
Allow the library builder to work with non-dart (json, xml, yaml, etc...) based on allow build extension

### DIFF
--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -73,9 +73,10 @@ class _Builder extends Builder {
   @override
   Future build(BuildStep buildStep) async {
     final resolver = buildStep.resolver;
+    final isLibrary = await resolver.isLibrary(buildStep.inputId);
+    final hasDartExtension = buildExtensions.containsKey(dartExtension);
 
-    if (!await resolver.isLibrary(buildStep.inputId) &&
-        buildExtensions.containsKey(dartExtension)) return;
+    if (!isLibrary && hasDartExtension) return;
 
     if (_generators.every((g) => g is GeneratorForAnnotation) &&
         !(await _hasAnyTopLevelAnnotations(
@@ -83,8 +84,10 @@ class _Builder extends Builder {
       return;
     }
 
-    final lib = await buildStep.resolver
-        .libraryFor(buildStep.inputId, allowSyntaxErrors: allowSyntaxErrors);
+    final lib = hasDartExtension
+        ? await buildStep.resolver
+            .libraryFor(buildStep.inputId, allowSyntaxErrors: allowSyntaxErrors)
+        : null;
     await _generateForLibrary(lib, buildStep);
   }
 

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -38,6 +38,8 @@ class _Builder extends Builder {
   @override
   final Map<String, List<String>> buildExtensions;
 
+  static const dartExtension = '.dart';
+
   /// Wrap [_generators] to form a [Builder]-compatible API.
   _Builder(
     this._generators, {
@@ -48,7 +50,7 @@ class _Builder extends Builder {
     this.allowSyntaxErrors = false,
   })  : _generatedExtension = generatedExtension,
         buildExtensions = {
-          '.dart': [
+          dartExtension: [
             generatedExtension,
             ...additionalOutputExtensions,
           ]
@@ -72,7 +74,8 @@ class _Builder extends Builder {
   Future build(BuildStep buildStep) async {
     final resolver = buildStep.resolver;
 
-    if (!await resolver.isLibrary(buildStep.inputId)) return;
+    if (!await resolver.isLibrary(buildStep.inputId) &&
+        buildExtensions.containsKey(dartExtension)) return;
 
     if (_generators.every((g) => g is GeneratorForAnnotation) &&
         !(await _hasAnyTopLevelAnnotations(

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.9.10+1
+version: 0.9.10+2
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
The current source generator only works with dart code even for LibraryBuilder, which kind not does not make sense. This change will support to generate code for non-dart extension.  