### PR TITLE
Add encoding default to readAsString override

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.9.10+4-dev
+
 ## 0.9.10+3
 
 * Allow the latest version of `package:analyzer`.

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 0.9.10+3
+version: 0.9.10+4-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -670,7 +670,7 @@ class _TestingBuildStep implements BuildStep {
   Future<bool> canRead(AssetId id) async => assets.containsKey(id);
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding}) async =>
+  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async =>
       assets[id];
 
   @override


### PR DESCRIPTION
There is a breaking change coming in `package:build` version `2.0.0` for
classes which override `readAsString` from `AssetReader`. The change is
a positive one since it enforces statically the guarantee of the default
encoding chosen which is currently stated in the doc but not enforced.

Prepare for this breaking change early to allow rolling the packages.
There may still be other breaking changes so it is not yet safe to
extend the dependency constraint.