### PR TITLE
Pass URI to AssetId.resolve

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,16 +37,16 @@ jobs:
       - name: mono_repo self validate
         run: pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_format; PKGS: _test_annotations, example, example_usage, source_gen; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
+    name: "analyze_format; Dart dev; PKGS: _test_annotations, example, example_usage; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test_annotations-example-example_usage-source_gen;commands:dartfmt-dartanalyzer"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test_annotations-example-example_usage;commands:dartfmt-dartanalyzer_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test_annotations-example-example_usage-source_gen
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test_annotations-example-example_usage
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -94,6 +94,25 @@ jobs:
         if: "always() && steps.example_usage_pub_upgrade.conclusion == 'success'"
         working-directory: example_usage
         run: dartanalyzer --fatal-infos --fatal-warnings .
+  job_003:
+    name: "analyze_format; Dart dev; PKG: source_gen; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:source_gen;commands:dartfmt-dartanalyzer_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:source_gen
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v0.3
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
       - id: source_gen_pub_upgrade
         name: "source_gen; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -103,12 +122,40 @@ jobs:
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
         run: dartfmt -n --set-exit-if-changed .
-      - name: "source_gen; dartanalyzer --fatal-infos --fatal-warnings ."
+      - name: "source_gen; dartanalyzer --fatal-infos ."
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
-        run: dartanalyzer --fatal-infos --fatal-warnings .
-  job_003:
-    name: "unit_test; PKG: example_usage; `pub run test --run-skipped`"
+        run: dartanalyzer --fatal-infos .
+  job_004:
+    name: "analyze_format; Dart 2.12.0; PKG: source_gen; `dartanalyzer .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:source_gen;commands:dartanalyzer_2"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:source_gen
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v0.3
+        with:
+          sdk: "2.12.0"
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: source_gen_pub_upgrade
+        name: "source_gen; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: source_gen
+        run: pub upgrade --no-precompile
+      - name: source_gen; dartanalyzer .
+        if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
+        working-directory: source_gen
+        run: dartanalyzer .
+  job_005:
+    name: "unit_test; Dart dev; PKG: example_usage; `pub run test --run-skipped`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -138,8 +185,43 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_004:
-    name: "unit_test; PKG: source_gen; `pub run test`"
+      - job_003
+      - job_004
+  job_006:
+    name: "unit_test; Dart 2.12.0; PKG: source_gen; `pub run test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:source_gen;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:source_gen
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v0.3
+        with:
+          sdk: "2.12.0"
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: source_gen_pub_upgrade
+        name: "source_gen; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: source_gen
+        run: pub upgrade --no-precompile
+      - name: source_gen; pub run test
+        if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
+        working-directory: source_gen
+        run: pub run test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_007:
+    name: "unit_test; Dart dev; PKG: source_gen; `pub run test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -169,3 +251,5 @@ jobs:
     needs:
       - job_001
       - job_002
+      - job_003
+      - job_004

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,10 @@ dependencies:
 dependency_overrides:
   source_gen:
     path: ../source_gen
+  build_resolvers:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build_resolvers
   build:
     git:
       url: git://github.com/dart-lang/build.git

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,9 +5,13 @@ environment:
 
 dependencies:
   analyzer: '>=0.42.0-nullsafety <2.0.0'
-  build: ^1.4.0
+  build: ^2.0.0
   source_gen: any
 
 dependency_overrides:
   source_gen:
     path: ../source_gen
+  build:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build

--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -13,6 +13,10 @@ dev_dependencies:
 dependency_overrides:
   source_gen:
     path: ../source_gen
+  build_resolvers:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build_resolvers
   build:
     git:
       url: git://github.com/dart-lang/build.git

--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -13,3 +13,7 @@ dev_dependencies:
 dependency_overrides:
   source_gen:
     path: ../source_gen
+  build:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build

--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -13,6 +13,18 @@ dev_dependencies:
 dependency_overrides:
   source_gen:
     path: ../source_gen
+  build_config:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build_config
+  build_runner:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build_runner
+  build_runner_core:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build_runner_core
   build_resolvers:
     git:
       url: git://github.com/dart-lang/build.git

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.9.10+4-dev
 
+* Upgrade to `package:build` version `2.0.0`.
 * Handle alias types with `DartType.aliasElement`.
 
 ## 0.9.10+3

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -358,7 +358,8 @@ Future<bool> _hasAnyTopLevelAnnotations(
   for (var directive in parsed.directives) {
     if (directive.metadata.isNotEmpty) return true;
     if (directive is PartDirective) {
-      partIds.add(AssetId.resolve(directive.uri.stringValue, from: input));
+      partIds.add(
+          AssetId.resolve(Uri.parse(directive.uri.stringValue), from: input));
     }
   }
   for (var declaration in parsed.declarations) {

--- a/source_gen/mono_pkg.yaml
+++ b/source_gen/mono_pkg.yaml
@@ -1,13 +1,17 @@
 # See https://github.com/google/mono_repo.dart for details
 dart:
+- 2.12.0
 - dev
 
 stages:
 - analyze_format:
   - group:
     - dartfmt
-    - dartanalyzer: --fatal-infos --fatal-warnings .
+    - dartanalyzer: --fatal-infos .
     dart: dev
+  - group:
+    - dartanalyzer: .
+    dart: 2.12.0
 - unit_test:
   - test
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 repository: https://github.com/dart-lang/source_gen
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: ">=2.11.999 <3.0.0"
 
 dependencies:
   analyzer: '>=0.42.0-nullsafety <2.0.0'

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>=0.42.0-nullsafety <2.0.0'
   async: ^2.0.7
-  build: ^1.4.0
+  build: ^2.0.0
   dart_style: ^1.0.0
   glob: ">=1.1.0 <3.0.0"
   meta: ^1.1.0
@@ -23,3 +23,9 @@ dev_dependencies:
     path: ../_test_annotations
   build_test: ^1.0.0
   test: ^1.0.0
+
+dependency_overrides:
+  build:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -25,6 +25,10 @@ dev_dependencies:
   test: ^1.0.0
 
 dependency_overrides:
+  build_resolvers:
+    git:
+      url: git://github.com/dart-lang/build.git
+      path: build_resolvers
   build:
     git:
       url: git://github.com/dart-lang/build.git

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -41,7 +41,7 @@ void main() {
       core = await resolver.findLibraryByName('dart.core');
       collection = await resolver.findLibraryByName('dart.collection');
       sourceGen = LibraryReader(await resolver
-          .libraryFor(AssetId.resolve('asset:source_gen/lib/source_gen.dart')));
+          .libraryFor(AssetId('source_gen', 'lib/source_gen.dart')));
     });
 
     final staticIterable = core.getType('Iterable').instantiate(

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -58,9 +58,17 @@ for PKG in ${PKGS}; do
       echo
       echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
       case ${TASK} in
-      dartanalyzer)
+      dartanalyzer_0)
         echo 'dartanalyzer --fatal-infos --fatal-warnings .'
         dartanalyzer --fatal-infos --fatal-warnings . || EXIT_CODE=$?
+        ;;
+      dartanalyzer_1)
+        echo 'dartanalyzer --fatal-infos .'
+        dartanalyzer --fatal-infos . || EXIT_CODE=$?
+        ;;
+      dartanalyzer_2)
+        echo 'dartanalyzer .'
+        dartanalyzer . || EXIT_CODE=$?
         ;;
       dartfmt)
         echo 'dartfmt -n --set-exit-if-changed .'


### PR DESCRIPTION
Updates for the breaking change in `package:build`.

- Use `Uri.parse` to convert to a URI, and migrate another call to the
  unnamed constructor since the URI is hardcoded and it can be resolved
  by hand.
- Override to the unpublished version of `build`.