### PR TITLE
Migrate source_gen to null-safety

### DIFF
--- a/_test_annotations/pubspec.yaml
+++ b/_test_annotations/pubspec.yaml
@@ -1,3 +1,3 @@
 name: _test_annotations
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,6 @@ dependency_overrides:
   # todo: Remove dart_style override before merging
   dart_style:
     git:
-      url: git@github.com:dart-lang/dart_style.git
+      url: https://github.com/dart-lang/dart_style.git
   source_gen:
     path: ../source_gen

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: source_gen_example
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   analyzer: '>=0.42.0-nullsafety <2.0.0'
@@ -9,5 +9,9 @@ dependencies:
   source_gen: any
 
 dependency_overrides:
+  # todo: Remove dart_style override before merging
+  dart_style:
+    git:
+      url: git@github.com:dart-lang/dart_style.git
   source_gen:
     path: ../source_gen

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,9 +9,5 @@ dependencies:
   source_gen: any
 
 dependency_overrides:
-  # todo: Remove dart_style override before merging
-  dart_style:
-    git:
-      url: https://github.com/dart-lang/dart_style.git
   source_gen:
     path: ../source_gen

--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -11,9 +11,7 @@ dev_dependencies:
   test: ^1.16.0
 
 dependency_overrides:
-  # todo: Remove before merging
-  dart_style:
-    git:
-      url: https://github.com/dart-lang/dart_style.git
+  # Temporarily necessary until build_runner supports the latest version
+  dart_style: ^2.0.0
   source_gen:
     path: ../source_gen

--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -12,18 +12,6 @@ dev_dependencies:
 
 dependency_overrides:
   # todo: Remove before merging
-  build_config:
-    git:
-      url: https://github.com/dart-lang/build.git
-      path: build_config
-  build_runner:
-    git:
-      url: https://github.com/dart-lang/build.git
-      path: build_runner
-  build_runner_core:
-    git:
-      url: https://github.com/dart-lang/build.git
-      path: build_runner_core
   dart_style:
     git:
       url: https://github.com/dart-lang/dart_style.git

--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -1,15 +1,31 @@
 name: source_gen_example_usage
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
-  build_runner: ^1.10.3
+  build_runner: ^1.12.0
   build_verify: ^1.1.0
   source_gen_example:
     path: ../example
-  test: ^1.5.1
+  test: ^1.16.0
 
 dependency_overrides:
+  # todo: Remove before merging
+  build_config:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_config
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
+  build_runner_core:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner_core
+  dart_style:
+    git:
+      url: https://github.com/dart-lang/dart_style.git
   source_gen:
     path: ../source_gen

--- a/example_usage/test/ensure_build_test.dart
+++ b/example_usage/test/ensure_build_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 @TestOn('vm')
 @Tags(['presubmit-only'])

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -22,12 +22,12 @@ import 'src/utils.dart';
 const _outputExtensions = '.g.dart';
 const _partFiles = '.g.part';
 
-Builder combiningBuilder([BuilderOptions options]) {
+Builder combiningBuilder([BuilderOptions? options]) {
   final optionsMap = Map<String, dynamic>.from(options?.config ?? {});
 
-  final includePartName = optionsMap.remove('include_part_name') as bool;
+  final includePartName = optionsMap.remove('include_part_name') as bool?;
   final ignoreForFile = Set<String>.from(
-    optionsMap.remove('ignore_for_file') as List ?? <String>[],
+    optionsMap.remove('ignore_for_file') as List? ?? <String>[],
   );
 
   final builder = CombiningBuilder(
@@ -36,11 +36,7 @@ Builder combiningBuilder([BuilderOptions options]) {
   );
 
   if (optionsMap.isNotEmpty) {
-    if (log == null) {
-      throw StateError('Upgrade `build_runner` to at least 0.8.2.');
-    } else {
-      log.warning('These options were ignored: `$optionsMap`.');
-    }
+    log.warning('These options were ignored: `$optionsMap`.');
   }
   return builder;
 }
@@ -67,8 +63,8 @@ class CombiningBuilder implements Builder {
   /// is output as a comment before its content. This can be useful when
   /// debugging build issues.
   const CombiningBuilder({
-    bool includePartName = false,
-    Set<String> ignoreForFile,
+    bool? includePartName = false,
+    Set<String>? ignoreForFile,
   })  : _includePartName = includePartName ?? false,
         _ignoreForFile = ignoreForFile ?? const <String>{};
 
@@ -89,7 +85,7 @@ class CombiningBuilder implements Builder {
       partIdRegExpLiteral, // A valid part ID
       RegExp.escape(_partFiles), // the ending part extension
       '\$', // end of string
-    ].join(''));
+    ].join());
 
     final assetIds = await buildStep
         .findAssets(Glob(pattern))

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -41,10 +41,10 @@ class _Builder extends Builder {
   /// Wrap [_generators] to form a [Builder]-compatible API.
   _Builder(
     this._generators, {
-    String Function(String code) formatOutput,
+    String Function(String code)? formatOutput,
     String generatedExtension = '.g.dart',
     List<String> additionalOutputExtensions = const [],
-    String header,
+    String? header,
     this.allowSyntaxErrors = false,
   })  : _generatedExtension = generatedExtension,
         buildExtensions = {
@@ -55,9 +55,6 @@ class _Builder extends Builder {
         },
         formatOutput = formatOutput ?? _formatter.format,
         _header = (header ?? defaultFileHeader).trim() {
-    if (_generatedExtension == null) {
-      throw ArgumentError.notNull('generatedExtension');
-    }
     if (_generatedExtension.isEmpty || !_generatedExtension.startsWith('.')) {
       throw ArgumentError.value(_generatedExtension, 'generatedExtension',
           'Extension must be in the format of .*');
@@ -109,14 +106,7 @@ class _Builder extends Builder {
     if (!_isLibraryBuilder) {
       final asset = buildStep.inputId;
       final name = nameOfPartial(library, asset);
-      if (name == null) {
-        final suggest = suggestLibraryName(asset);
-        throw InvalidGenerationSourceError(
-            'Could not find library identifier so a "part of" cannot be built.',
-            todo: ''
-                'Consider adding the following to your source file:\n\n'
-                'library $suggest;');
-      }
+
       contentBuffer.writeln();
 
       String part;
@@ -212,7 +202,7 @@ class SharedPartBuilder extends _Builder {
   SharedPartBuilder(
     List<Generator> generators,
     String partId, {
-    String Function(String code) formatOutput,
+    String Function(String code)? formatOutput,
     List<String> additionalOutputExtensions = const [],
     bool allowSyntaxErrors = false,
   }) : super(
@@ -267,9 +257,9 @@ class PartBuilder extends _Builder {
   PartBuilder(
     List<Generator> generators,
     String generatedExtension, {
-    String Function(String code) formatOutput,
+    String Function(String code)? formatOutput,
     List<String> additionalOutputExtensions = const [],
-    String header,
+    String? header,
     bool allowSyntaxErrors = false,
   }) : super(
           generators,
@@ -307,10 +297,10 @@ class LibraryBuilder extends _Builder {
   /// libraries.
   LibraryBuilder(
     Generator generator, {
-    String Function(String code) formatOutput,
+    String Function(String code)? formatOutput,
     String generatedExtension = '.g.dart',
     List<String> additionalOutputExtensions = const [],
-    String header,
+    String? header,
     bool allowSyntaxErrors = false,
   }) : super(
           [generator],
@@ -358,8 +348,10 @@ Future<bool> _hasAnyTopLevelAnnotations(
   for (var directive in parsed.directives) {
     if (directive.metadata.isNotEmpty) return true;
     if (directive is PartDirective) {
-      partIds.add(
-          AssetId.resolve(Uri.parse(directive.uri.stringValue), from: input));
+      final uri = directive.uri.stringValue;
+      if (uri != null) {
+        partIds.add(AssetId.resolve(Uri.parse(uri), from: input));
+      }
     }
   }
   for (var declaration in parsed.declarations) {

--- a/source_gen/lib/src/constants/reader.dart
+++ b/source_gen/lib/src/constants/reader.dart
@@ -16,8 +16,8 @@ import 'utils.dart';
 /// Unlike [DartObject.getField], the [read] method attempts to access super
 /// classes for the field value if not found.
 abstract class ConstantReader {
-  factory ConstantReader(DartObject object) =>
-      isNullLike(object) ? const _NullConstant() : _DartObjectConstant(object);
+  factory ConstantReader(DartObject? object) =>
+      isNullLike(object) ? const _NullConstant() : _DartObjectConstant(object!);
 
   const ConstantReader._();
 
@@ -31,7 +31,7 @@ abstract class ConstantReader {
   /// is the case if the constant is not a literal or if the literal value
   /// is represented at least partially with [DartObject] instances.
   @Deprecated('Use `literalValue`, will be removed in 0.8.0')
-  Object get anyValue => literalValue;
+  Object? get anyValue => literalValue;
 
   /// Whether this constant is a literal value.
   bool get isLiteral => true;
@@ -41,7 +41,7 @@ abstract class ConstantReader {
   /// Throws [FormatException] if a valid literal value cannot be returned. This
   /// is the case if the constant is not a literal or if the literal value
   /// is represented at least partially with [DartObject] instances.
-  Object get literalValue => null;
+  Object? get literalValue => null;
 
   /// Underlying object this instance is reading from.
   DartObject get objectValue;
@@ -59,7 +59,7 @@ abstract class ConstantReader {
   /// Reads [field] from the constant as another constant value.
   ///
   /// Unlike [read], returns `null` if the field is not found.
-  ConstantReader peek(String field);
+  ConstantReader? peek(String field);
 
   /// Whether this constant is a `null` value.
   bool get isNull => true;
@@ -104,7 +104,7 @@ abstract class ConstantReader {
   bool get isMap => false;
 
   /// Constant as a `Map` value.
-  Map<DartObject, DartObject> get mapValue;
+  Map<DartObject?, DartObject?> get mapValue;
 
   /// Whether this constant represents a `List` value.
   bool get isList => false;
@@ -156,7 +156,7 @@ class _NullConstant extends ConstantReader {
   Map<DartObject, DartObject> get mapValue => _throw('Map');
 
   @override
-  ConstantReader peek(_) => null;
+  ConstantReader? peek(_) => null;
 
   @override
   ConstantReader read(_) => throw UnsupportedError('Null');
@@ -180,7 +180,7 @@ class _DartObjectConstant extends ConstantReader {
 
   const _DartObjectConstant(this.objectValue) : super._();
 
-  T _check<T>(T value, String expected) {
+  T _check<T>(T? value, String expected) {
     if (value == null) {
       throw FormatException('Not an instance of $expected.', objectValue);
     }
@@ -212,7 +212,8 @@ class _DartObjectConstant extends ConstantReader {
 
   @override
   bool instanceOf(TypeChecker checker) =>
-      checker.isAssignableFromType(objectValue.type);
+      objectValue.type != null &&
+      checker.isAssignableFromType(objectValue.type!);
 
   @override
   bool get isNull => isNullLike(objectValue);
@@ -251,7 +252,7 @@ class _DartObjectConstant extends ConstantReader {
   bool get isMap => objectValue.toMapValue() != null;
 
   @override
-  Map<DartObject, DartObject> get mapValue =>
+  Map<DartObject?, DartObject?> get mapValue =>
       _check(objectValue.toMapValue(), 'Map');
 
   @override
@@ -274,7 +275,7 @@ class _DartObjectConstant extends ConstantReader {
   DartType get typeValue => _check(objectValue.toTypeValue(), 'Type');
 
   @override
-  ConstantReader peek(String field) {
+  ConstantReader? peek(String field) {
     final constant = ConstantReader(getFieldRecursive(objectValue, field));
     return constant.isNull ? null : constant;
   }
@@ -283,7 +284,7 @@ class _DartObjectConstant extends ConstantReader {
   ConstantReader read(String field) {
     final reader = peek(field);
     if (reader == null) {
-      assertHasField(objectValue?.type?.element as ClassElement, field);
+      assertHasField(objectValue.type?.element as ClassElement, field);
       return const _NullConstant();
     }
     return reader;

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -19,14 +19,14 @@ import '../utils.dart';
 /// **NOTE**: Some returned [Revivable] instances are not representable as valid
 /// Dart source code (such as referencing private constructors). It is up to the
 /// build tool(s) using this library to surface error messages to the user.
-Revivable reviveInstance(DartObject object, [LibraryElement origin]) {
+Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   final objectType = object.type;
-  Element element = object.type.aliasElement;
+  Element? element = objectType?.aliasElement;
   if (element == null) {
     if (objectType is InterfaceType) {
       element = objectType.element;
     } else {
-      element = object.toFunctionValue();
+      element = object.toFunctionValue()!;
     }
   }
   origin ??= element.library;
@@ -64,7 +64,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement origin]) {
     return !result.isPrivate;
   }
 
-  for (final e in origin.definingCompilationUnit.types
+  for (final e in origin!.definingCompilationUnit.types
       .expand((t) => t.fields)
       .where((f) => f.isConst && f.computeConstantValue() == object)) {
     final result = Revivable._(
@@ -88,19 +88,19 @@ Revivable reviveInstance(DartObject object, [LibraryElement origin]) {
       return result;
     }
   }
-  if (origin != null) {
-    for (final e in origin.definingCompilationUnit.topLevelVariables.where(
-      (f) => f.isConst && f.computeConstantValue() == object,
-    )) {
-      final result = Revivable._(
-        source: Uri.parse(urlOfElement(origin)).replace(fragment: ''),
-        accessor: e.name,
-      );
-      if (tryResult(result)) {
-        return result;
-      }
+
+  for (final e in origin.definingCompilationUnit.topLevelVariables.where(
+    (f) => f.isConst && f.computeConstantValue() == object,
+  )) {
+    final result = Revivable._(
+      source: Uri.parse(urlOfElement(origin)).replace(fragment: ''),
+      accessor: e.name,
+    );
+    if (tryResult(result)) {
+      return result;
     }
   }
+
   // We could try and return the "best" result more intelligently.
   return allResults.first;
 }
@@ -128,7 +128,7 @@ class Revivable {
   final Map<String, DartObject> namedArguments;
 
   const Revivable._({
-    this.source,
+    required this.source,
     this.accessor = '',
     this.positionalArguments = const [],
     this.namedArguments = const {},

--- a/source_gen/lib/src/constants/utils.dart
+++ b/source_gen/lib/src/constants/utils.dart
@@ -9,7 +9,7 @@ import 'package:analyzer/dart/element/element.dart';
 ///
 /// Super types [ClassElement.supertype] are also checked before throwing.
 void assertHasField(ClassElement root, String name) {
-  var element = root;
+  ClassElement? element = root;
   while (element != null) {
     final field = element.getField(name);
     if (field != null) {
@@ -26,16 +26,16 @@ void assertHasField(ClassElement root, String name) {
 }
 
 /// Returns whether or not [object] is or represents a `null` value.
-bool isNullLike(DartObject object) => object?.isNull != false;
+bool isNullLike(DartObject? object) => object?.isNull != false;
 
 /// Similar to [DartObject.getField], but traverses super classes.
 ///
 /// Returns `null` if ultimately [field] is never found.
-DartObject getFieldRecursive(DartObject object, String field) {
+DartObject? getFieldRecursive(DartObject? object, String field) {
   if (isNullLike(object)) {
     return null;
   }
-  final result = object.getField(field);
+  final result = object!.getField(field);
   if (isNullLike(result)) {
     return getFieldRecursive(object.getField('(super)'), field);
   }

--- a/source_gen/lib/src/generated_output.dart
+++ b/source_gen/lib/src/generated_output.dart
@@ -9,8 +9,7 @@ class GeneratedOutput {
   final String generatorDescription;
 
   GeneratedOutput(Generator generator, this.output)
-      : assert(output != null),
-        assert(output.isNotEmpty),
+      : assert(output.isNotEmpty),
         // assuming length check is cheaper than simple string equality
         assert(output.length == output.trim().length),
         generatorDescription = _toString(generator);

--- a/source_gen/lib/src/generator.dart
+++ b/source_gen/lib/src/generator.dart
@@ -22,7 +22,8 @@ abstract class Generator {
   /// output is Dart code returned through the Future. If there is nothing to
   /// generate for this library may return null, or a Future that resolves to
   /// null or the empty string.
-  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) => null;
+  FutureOr<String?> generate(LibraryReader library, BuildStep buildStep) =>
+      null;
 
   @override
   String toString() => runtimeType.toString();
@@ -41,9 +42,9 @@ class InvalidGenerationSourceError extends Error {
   /// The code element associated with this error.
   ///
   /// May be `null` if the error had no associated element.
-  final Element element;
+  final Element? element;
 
-  InvalidGenerationSourceError(this.message, {String todo, this.element})
+  InvalidGenerationSourceError(this.message, {String? todo, this.element})
       : todo = todo ?? '';
 
   @override
@@ -52,7 +53,7 @@ class InvalidGenerationSourceError extends Error {
 
     if (element != null) {
       try {
-        final span = spanForElement(element);
+        final span = spanForElement(element!);
         buffer
           ..writeln()
           ..writeln(span.start.toolString)

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -53,7 +53,7 @@ abstract class GeneratorForAnnotation<T> extends Generator {
       final generatedValue = generateForAnnotatedElement(
           annotatedElement.element, annotatedElement.annotation, buildStep);
       await for (var value in normalizeGeneratorOutput(generatedValue)) {
-        assert(value == null || (value.length == value.trim().length));
+        assert(value.length == value.trim().length);
         values.add(value);
       }
     }

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -28,7 +28,7 @@ class LibraryReader {
   ///
   /// Unlike [LibraryElement.getType], this also correctly traverses identifiers
   /// that are accessible via one or more `export` directives.
-  ClassElement findType(String name) {
+  ClassElement? findType(String name) {
     final type = element.exportNamespace.get(name);
     return type is ClassElement ? type : null;
   }
@@ -49,7 +49,7 @@ class LibraryReader {
 
   /// All of the declarations in this library annotated with [checker].
   Iterable<AnnotatedElement> annotatedWith(TypeChecker checker,
-      {bool throwOnUnresolved}) sync* {
+      {bool? throwOnUnresolved}) sync* {
     for (final element in allElements) {
       final annotation = checker.firstAnnotationOf(element,
           throwOnUnresolved: throwOnUnresolved);
@@ -61,7 +61,7 @@ class LibraryReader {
 
   /// All of the declarations in this library annotated with exactly [checker].
   Iterable<AnnotatedElement> annotatedWithExact(TypeChecker checker,
-      {bool throwOnUnresolved}) sync* {
+      {bool? throwOnUnresolved}) sync* {
     for (final element in allElements) {
       final annotation = checker.firstAnnotationOfExact(element,
           throwOnUnresolved: throwOnUnresolved);
@@ -81,7 +81,13 @@ class LibraryReader {
   ///
   /// This is a typed convenience function for using [pathToUrl], and the same
   /// API restrictions hold around supported schemes and relative paths.
-  Uri pathToElement(Element element) => pathToUrl(element.source.uri);
+  Uri pathToElement(Element element) {
+    final source = element.source;
+    if (source == null) {
+      throw ArgumentError.value(element, 'element', 'Does not have a source');
+    }
+    return pathToUrl(source.uri);
+  }
 
   /// Returns a [Uri] from the current library to the one provided.
   ///
@@ -120,9 +126,6 @@ class LibraryReader {
         return assetToPackageUrl(to);
       }
       var from = element.source.uri;
-      if (from == null) {
-        throw StateError('Current library has no source URL');
-      }
       // Normalize (convert to an asset: URL).
       from = normalizeUrl(from);
       if (_isRelative(from, to)) {

--- a/source_gen/lib/src/output_helpers.dart
+++ b/source_gen/lib/src/output_helpers.dart
@@ -7,7 +7,7 @@ import 'package:async/async.dart';
 /// Converts [Future], [Iterable], and [Stream] implementations
 /// containing [String] to a single [Stream] while ensuring all thrown
 /// exceptions are forwarded through the return value.
-Stream<String> normalizeGeneratorOutput(Object value) {
+Stream<String> normalizeGeneratorOutput(Object? value) {
   if (value == null) {
     return const Stream.empty();
   } else if (value is Future) {
@@ -17,7 +17,7 @@ Stream<String> normalizeGeneratorOutput(Object value) {
   }
 
   if (value is Iterable) {
-    value = Stream.fromIterable(value as Iterable);
+    value = Stream.fromIterable(value);
   }
 
   if (value is Stream) {
@@ -32,6 +32,6 @@ Stream<String> normalizeGeneratorOutput(Object value) {
   throw _argError(value);
 }
 
-ArgumentError _argError(Object value) => ArgumentError(
+ArgumentError _argError(Object? value) => ArgumentError(
     'Must be a String or be an Iterable/Stream containing String values. '
     'Found `${Error.safeToString(value)}` (${value.runtimeType}).');

--- a/source_gen/lib/src/span_for_element.dart
+++ b/source_gen/lib/src/span_for_element.dart
@@ -18,33 +18,27 @@ import 'utils.dart';
 ///
 /// Not all results from the analyzer API may return source information as part
 /// of the element, so [file] may need to be manually provided in those cases.
-SourceSpan spanForElement(Element element, [SourceFile file]) {
-  final url = assetToPackageUrl(element.source.uri);
+SourceSpan spanForElement(Element element, [SourceFile? file]) {
+  final source = element.source;
+  if (source == null && file == null) {
+    throw ArgumentError(
+        'The element does not have a source, and no alternative file was '
+        'provided.');
+  }
+
   if (file == null) {
-    final contents = element?.source?.contents;
-    if (contents == null) {
-      return SourceSpan(
-        SourceLocation(
-          element.nameOffset,
-          sourceUrl: url,
-        ),
-        SourceLocation(
-          element.nameOffset + element.nameLength,
-          sourceUrl: url,
-        ),
-        element.name,
-      );
-    }
+    final url = assetToPackageUrl(source!.uri);
+    final contents = source.contents;
     file = SourceFile.fromString(contents.data, url: url);
   }
   if (element.nameOffset < 0) {
     if (element is PropertyInducingElement) {
       if (element.getter != null) {
-        return spanForElement(element.getter);
+        return spanForElement(element.getter!);
       }
 
       if (element.setter != null) {
-        return spanForElement(element.setter);
+        return spanForElement(element.setter!);
       }
     }
   }

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -35,11 +35,10 @@ String typeNameOf(DartType type) {
 }
 
 /// Returns a name suitable for `part of "..."` when pointing to [element].
-///
-/// Returns `null` if [element] is missing identifier.
 String nameOfPartial(LibraryElement element, AssetId source) {
-  if (element.name != null && element.name.isNotEmpty) {
-    return element.name;
+  final name = element.name;
+  if (name != null && name.isNotEmpty) {
+    return name;
   }
 
   final sourceUrl = p.basename(source.uri.toString());
@@ -69,7 +68,7 @@ String computePartUrl(AssetId input, AssetId output) =>
 String urlOfElement(Element element) => element.kind == ElementKind.DYNAMIC
     ? 'dart:core#dynamic'
     // using librarySource.uri – in case the element is in a part
-    : normalizeUrl(element.librarySource.uri)
+    : normalizeUrl(element.librarySource!.uri)
         .replace(fragment: element.name)
         .toString();
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
 dependency_overrides:
   dart_style:
     git:
-      url: git@github.com:dart-lang/dart_style.git
+      url: https://github.com/dart-lang/dart_style.git

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -23,8 +23,3 @@ dev_dependencies:
     path: ../_test_annotations
   build_test: ^2.0.0
   test: ^1.16.0
-
-dependency_overrides:
-  dart_style:
-    git:
-      url: https://github.com/dart-lang/dart_style.git

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -5,22 +5,26 @@ description: >-
 repository: https://github.com/dart-lang/source_gen
 
 environment:
-  sdk: ">=2.11.999 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.42.0 <2.0.0'
-  async: ^2.0.7
+  analyzer: '>=0.42.0-nullsafety <2.0.0'
+  async: ^2.5.0
   build: ^2.0.0
-  dart_style: ^1.0.0
-  glob: ">=1.1.0 <3.0.0"
-  meta: ^1.1.0
-  path: ^1.3.2
-  pedantic: ^1.0.0
-  source_span: ^1.4.0
+  dart_style: ^2.0.0
+  glob: ^2.0.0
+  meta: ^1.3.0
+  path: ^1.8.0
+  pedantic: ^1.10.0
+  source_span: ^1.8.1
 
 dev_dependencies:
   _test_annotations:
     path: ../_test_annotations
   build_test: ^2.0.0
-  test: ^1.0.0
+  test: ^1.16.0
 
+dependency_overrides:
+  dart_style:
+    git:
+      url: git@github.com:dart-lang/dart_style.git

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -617,25 +617,25 @@ Future _generateTest(CommentGenerator gen, String expectedContent) async {
 }
 
 Map<String, String> _createPackageStub(
-        {String testLibContent, String testLibPartContent}) =>
+        {String? testLibContent, String? testLibPartContent}) =>
     {
       '$_pkgName|lib/test_lib.dart': testLibContent ?? _testLibContent,
       '$_pkgName|lib/test_lib.foo.dart':
           testLibPartContent ?? _testLibPartContent,
     };
 
-PartBuilder _unformattedLiteral([String content]) =>
+PartBuilder _unformattedLiteral([String? content]) =>
     PartBuilder([_LiteralGenerator(content)], '.foo.dart',
         formatOutput: (s) => s);
 
 /// Returns the [String] provided in the constructor, or `null`.
 class _LiteralGenerator extends Generator {
-  final String _content;
+  final String? _content;
 
   const _LiteralGenerator([this._content]);
 
   @override
-  String generate(_, __) => _content;
+  String? generate(_, __) => _content;
 }
 
 class _BadOutputGenerator extends Generator {
@@ -671,7 +671,7 @@ class _TestingBuildStep implements BuildStep {
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async =>
-      assets[id];
+      assets[id]!;
 
   @override
   void noSuchMethod(_) => throw UnimplementedError();
@@ -688,7 +688,7 @@ class _TestingResolver implements Resolver {
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,
       {bool allowSyntaxErrors = false}) async {
     parsedUnits.add(assetId);
-    return parseString(content: assets[assetId]).unit;
+    return parseString(content: assets[assetId]!).unit;
   }
 
   @override
@@ -701,7 +701,7 @@ class _TestingResolver implements Resolver {
   Future<LibraryElement> libraryFor(AssetId assetId,
       {bool allowSyntaxErrors = false}) async {
     resolvedLibs.add(assetId);
-    return null;
+    throw NonLibraryAssetException(assetId);
   }
 
   @override

--- a/source_gen/test/constants/utils_test.dart
+++ b/source_gen/test/constants/utils_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('assertHasField', () {
-    LibraryElement testLib;
+    late LibraryElement testLib;
 
     setUpAll(() async {
-      testLib = await resolveSource(r'''
+      testLib = (await resolveSource(r'''
           library test_lib;
 
           class A {
@@ -27,30 +27,30 @@ void main() {
           class C {
             String c;
           }
-          ''', (resolver) => resolver.findLibraryByName('test_lib'));
+          ''', (resolver) => resolver.findLibraryByName('test_lib')))!;
     });
 
     test('should not throw when a class contains a field', () {
-      final $A = testLib.getType('A');
+      final $A = testLib.getType('A')!;
       expect(() => assertHasField($A, 'a'), returnsNormally);
     });
 
     test('should not throw when a super class contains a field', () {
-      final $B = testLib.getType('B');
+      final $B = testLib.getType('B')!;
       expect(() => assertHasField($B, 'a'), returnsNormally);
     });
 
     test('should throw when a class does not contain a field', () {
-      final $C = testLib.getType('C');
+      final $C = testLib.getType('C')!;
       expect(() => assertHasField($C, 'a'), throwsFormatException);
     });
   });
 
   group('getFieldRecursive', () {
-    List<DartObject> objects;
+    late List<DartObject?> objects;
 
     setUpAll(() async {
-      final testLib = await resolveSource(r'''
+      final testLib = (await resolveSource(r'''
           library test_lib;
 
           @A('a-value')
@@ -75,21 +75,21 @@ void main() {
 
             const C(this.c);
           }
-          ''', (resolver) => resolver.findLibraryByName('test_lib'));
+          ''', (resolver) => resolver.findLibraryByName('test_lib')))!;
       objects = testLib
-          .getType('Example')
+          .getType('Example')!
           .metadata
           .map((e) => e.computeConstantValue())
           .toList();
     });
 
     test('should find a field directly on an object', () {
-      expect(getFieldRecursive(objects[0], 'a').toStringValue(), 'a-value');
+      expect(getFieldRecursive(objects[0], 'a')?.toStringValue(), 'a-value');
     });
 
     test('should find a field available on a super', () {
-      expect(getFieldRecursive(objects[1], 'b').toStringValue(), 'b-value');
-      expect(getFieldRecursive(objects[1], 'a').toStringValue(), 'a-value');
+      expect(getFieldRecursive(objects[1], 'b')?.toStringValue(), 'b-value');
+      expect(getFieldRecursive(objects[1], 'a')?.toStringValue(), 'a-value');
     });
 
     test('should return null when a field is not found', () {

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Constant', () {
-    List<ConstantReader> constants;
+    late List<ConstantReader> constants;
 
     setUpAll(() async {
       final library = await resolveSource(r'''
@@ -58,8 +58,8 @@ void main() {
           const Super() : super(aString: 'Super Hello');
         }
       ''', (resolver) => resolver.findLibraryByName('test_lib'));
-      constants = library
-          .getType('Example')
+      constants = library!
+          .getType('Example')!
           .metadata
           .map((e) => ConstantReader(e.computeConstantValue()))
           .toList();
@@ -146,7 +146,7 @@ void main() {
 
     test('should read a Type', () {
       expect(constants[11].isType, isTrue);
-      expect(constants[11].typeValue.element.name, 'DateTime');
+      expect(constants[11].typeValue.element!.name, 'DateTime');
       expect(constants[11].isLiteral, isFalse);
       expect(() => constants[11].literalValue, throwsFormatException);
     });
@@ -196,7 +196,7 @@ void main() {
   });
 
   group('Reviable', () {
-    List<ConstantReader> constants;
+    late List<ConstantReader> constants;
 
     setUpAll(() async {
       final library = await resolveSource(r'''
@@ -277,8 +277,8 @@ void main() {
 
         void _privateFunction() {}
       ''', (resolver) => resolver.findLibraryByName('test_lib'));
-      constants = library
-          .getType('Example')
+      constants = library!
+          .getType('Example')!
           .metadata
           .map((e) => ConstantReader(e.computeConstantValue()))
           .toList();

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -109,12 +109,12 @@ class RepeatingGenerator extends GeneratorForAnnotation<Deprecated> {
 }
 
 class LiteralOutput<T> extends GeneratorForAnnotation<Deprecated> {
-  final T value;
+  final T? value;
 
   const LiteralOutput([this.value]);
 
   @override
-  T generateForAnnotatedElement(
+  T? generateForAnnotatedElement(
           Element element, ConstantReader annotation, BuildStep buildStep) =>
       null;
 }

--- a/source_gen/test/library/find_type_test.dart
+++ b/source_gen/test/library/find_type_test.dart
@@ -29,12 +29,12 @@ enum PartEnum{A,B}
 ''';
 
 void main() {
-  LibraryReader library;
+  late LibraryReader library;
 
   setUpAll(() async {
     library = await resolveSources(
       {'a|source.dart': _source, 'a|part.dart': _partSource},
-      (r) async => LibraryReader(await r.findLibraryByName('test_lib')),
+      (r) async => LibraryReader((await r.findLibraryByName('test_lib'))!),
     );
   });
 

--- a/source_gen/test/library/path_to_url_test.dart
+++ b/source_gen/test/library/path_to_url_test.dart
@@ -9,7 +9,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 void main() {
-  LibraryReader reader;
+  late LibraryReader reader;
 
   final packageA = Uri.parse('package:a/a.dart');
   final packageB = Uri.parse('package:b/b.dart');

--- a/source_gen/test/output_helpers_test.dart
+++ b/source_gen/test/output_helpers_test.dart
@@ -42,7 +42,7 @@ void main() {
   });
 }
 
-void _testSimpleValue(String testName, Object value, expected) {
+void _testSimpleValue(String testName, Object? value, expected) {
   _testFunction(testName, value, expected);
 
   assert(value is! Future);

--- a/source_gen/test/span_for_element_test.dart
+++ b/source_gen/test/span_for_element_test.dart
@@ -9,10 +9,10 @@ import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 void main() {
-  LibraryElement library;
+  late LibraryElement library;
 
   setUpAll(() async {
-    library = await resolveSource(r'''
+    library = (await resolveSource(r'''
 library test_lib;
 
 abstract class Example implements List {
@@ -25,12 +25,12 @@ abstract class Example implements List {
   }
 }
 ''', (resolver) => resolver.findLibraryByName('test_lib'),
-        inputId: AssetId('test_lib', 'lib/test_lib.dart'));
+        inputId: AssetId('test_lib', 'lib/test_lib.dart')))!;
   });
 
   test('should highlight the use of "class Example"', () async {
     expect(
-        spanForElement(library.getType('Example')).message('Here it is'), r'''
+        spanForElement(library.getType('Example')!).message('Here it is'), r'''
 line 3, column 16 of package:test_lib/test_lib.dart: Here it is
   ╷
 3 │ abstract class Example implements List {
@@ -40,7 +40,7 @@ line 3, column 16 of package:test_lib/test_lib.dart: Here it is
 
   test('should correctly highlight getter', () async {
     expect(
-        spanForElement(library.getType('Example').getField('getter'))
+        spanForElement(library.getType('Example')!.getField('getter')!)
             .message('Here it is'),
         r'''
 line 4, column 15 of package:test_lib/test_lib.dart: Here it is
@@ -52,7 +52,7 @@ line 4, column 15 of package:test_lib/test_lib.dart: Here it is
 
   test('should correctly highlight setter', () async {
     expect(
-        spanForElement(library.getType('Example').getField('setter'))
+        spanForElement(library.getType('Example')!.getField('setter')!)
             .message('Here it is'),
         r'''
 line 5, column 7 of package:test_lib/test_lib.dart: Here it is
@@ -64,7 +64,7 @@ line 5, column 7 of package:test_lib/test_lib.dart: Here it is
 
   test('should correctly highlight field', () async {
     expect(
-        spanForElement(library.getType('Example').getField('field'))
+        spanForElement(library.getType('Example')!.getField('field')!)
             .message('Here it is'),
         r'''
 line 6, column 7 of package:test_lib/test_lib.dart: Here it is
@@ -76,7 +76,7 @@ line 6, column 7 of package:test_lib/test_lib.dart: Here it is
 
   test('highlight getter with getter/setter property', () async {
     expect(
-        spanForElement(library.getType('Example').getField('fieldProp'))
+        spanForElement(library.getType('Example')!.getField('fieldProp')!)
             .message('Here it is'),
         r'''
 line 7, column 11 of package:test_lib/test_lib.dart: Here it is

--- a/source_gen/test/src/comment_generator.dart
+++ b/source_gen/test/src/comment_generator.dart
@@ -16,7 +16,7 @@ class CommentGenerator extends Generator {
     final output = <String>[];
     if (forLibrary) {
       var name = library.element.name;
-      if (name.isEmpty) {
+      if (name == null || name.isEmpty) {
         name = library.element.source.uri.pathSegments.last;
       }
       output.add('// Code for "$name"');

--- a/source_gen/test/test_files/annotations.dart
+++ b/source_gen/test/test_files/annotations.dart
@@ -19,8 +19,8 @@ class PublicAnnotationClass {
   final String aString;
   final List aList;
   final bool aBool;
-  final PublicAnnotationClass child1;
-  final PublicAnnotationClass child2;
+  final PublicAnnotationClass? child1;
+  final PublicAnnotationClass? child2;
 
   const PublicAnnotationClass()
       : anInt = 0,

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -11,67 +11,66 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
-import 'package:meta/meta.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 void main() {
   // Resolved top-level types from dart:core and dart:collection.
-  InterfaceType staticUri;
-  InterfaceType staticMap;
-  InterfaceType staticHashMap;
-  InterfaceType staticUnmodifiableListView;
-  TypeChecker staticIterableChecker;
-  TypeChecker staticMapChecker;
-  TypeChecker staticHashMapChecker;
+  late InterfaceType staticUri;
+  late InterfaceType staticMap;
+  late InterfaceType staticHashMap;
+  late InterfaceType staticUnmodifiableListView;
+  late TypeChecker staticIterableChecker;
+  late TypeChecker staticMapChecker;
+  late TypeChecker staticHashMapChecker;
 
   // Resolved top-level types from package:source_gen.
-  InterfaceType staticGenerator;
-  InterfaceType staticGeneratorForAnnotation;
-  TypeChecker staticGeneratorChecker;
-  TypeChecker staticGeneratorForAnnotationChecker;
+  late InterfaceType staticGenerator;
+  late InterfaceType staticGeneratorForAnnotation;
+  late TypeChecker staticGeneratorChecker;
+  late TypeChecker staticGeneratorForAnnotationChecker;
 
   setUpAll(() async {
-    LibraryElement core;
-    LibraryElement collection;
-    LibraryReader sourceGen;
+    late LibraryElement core;
+    late LibraryElement collection;
+    late LibraryReader sourceGen;
     await resolveSource(r'''
       export 'package:source_gen/source_gen.dart';
     ''', (resolver) async {
-      core = await resolver.findLibraryByName('dart.core');
-      collection = await resolver.findLibraryByName('dart.collection');
-      sourceGen = LibraryReader(await resolver
-          .libraryFor(AssetId('source_gen', 'lib/source_gen.dart')));
+      core = (await resolver.findLibraryByName('dart.core'))!;
+      collection = (await resolver.findLibraryByName('dart.collection'))!;
+      sourceGen = LibraryReader(await resolver.libraryFor(
+          AssetId.resolve(Uri.parse('asset:source_gen/lib/source_gen.dart'))));
     });
 
-    final staticIterable = core.getType('Iterable').instantiate(
+    final staticIterable = core.getType('Iterable')!.instantiate(
         typeArguments: [core.typeProvider.dynamicType],
         nullabilitySuffix: NullabilitySuffix.none);
     staticIterableChecker = TypeChecker.fromStatic(staticIterable);
-    staticUri = core.getType('Uri').instantiate(
+    staticUri = core.getType('Uri')!.instantiate(
         typeArguments: [], nullabilitySuffix: NullabilitySuffix.none);
-    staticMap = core.getType('Map').instantiate(typeArguments: [
+    staticMap = core.getType('Map')!.instantiate(typeArguments: [
       core.typeProvider.dynamicType,
       core.typeProvider.dynamicType
     ], nullabilitySuffix: NullabilitySuffix.none);
     staticMapChecker = TypeChecker.fromStatic(staticMap);
 
-    staticHashMap = collection.getType('HashMap').instantiate(typeArguments: [
+    staticHashMap = collection.getType('HashMap')!.instantiate(typeArguments: [
       core.typeProvider.dynamicType,
       core.typeProvider.dynamicType
     ], nullabilitySuffix: NullabilitySuffix.none);
     staticHashMapChecker = TypeChecker.fromStatic(staticHashMap);
     staticUnmodifiableListView = collection
-        .getType('UnmodifiableListView')
+        .getType('UnmodifiableListView')!
         .instantiate(
             typeArguments: [core.typeProvider.dynamicType],
             nullabilitySuffix: NullabilitySuffix.none);
 
-    staticGenerator = sourceGen.findType('Generator').instantiate(
+    staticGenerator = sourceGen.findType('Generator')!.instantiate(
         typeArguments: [], nullabilitySuffix: NullabilitySuffix.none);
     staticGeneratorChecker = TypeChecker.fromStatic(staticGenerator);
     staticGeneratorForAnnotation = sourceGen
-        .findType('GeneratorForAnnotation')
+        .findType('GeneratorForAnnotation')!
         .instantiate(
             typeArguments: [core.typeProvider.dynamicType],
             nullabilitySuffix: NullabilitySuffix.none);
@@ -81,11 +80,11 @@ void main() {
 
   // Run a common set of type comparison checks with various implementations.
   void commonTests({
-    @required TypeChecker Function() checkIterable,
-    @required TypeChecker Function() checkMap,
-    @required TypeChecker Function() checkHashMap,
-    @required TypeChecker Function() checkGenerator,
-    @required TypeChecker Function() checkGeneratorForAnnotation,
+    required TypeChecker Function() checkIterable,
+    required TypeChecker Function() checkMap,
+    required TypeChecker Function() checkHashMap,
+    required TypeChecker Function() checkGenerator,
+    required TypeChecker Function() checkGeneratorForAnnotation,
   }) {
     group('(Iterable)', () {
       test('should be assignable from dart:collection#UnmodifiableListView',
@@ -122,7 +121,7 @@ void main() {
       test('should be assignable from Map<String, String>', () {
         // Using Uri.queryParameters to get a Map<String, String>
         final stringStringMapType =
-            staticUri.getGetter('queryParameters').returnType;
+            staticUri.getGetter('queryParameters')!.returnType;
 
         expect(checkMap().isAssignableFromType(stringStringMapType), isTrue);
         expect(checkMap().isExactlyType(stringStringMapType), isTrue);
@@ -211,7 +210,7 @@ void main() {
       @depracated // Intentionally mispelled.
       class X {}
     ''', (resolver) => resolver.findLibraryByName('_test'));
-    final classX = library.getType('X');
+    final classX = library!.getType('X')!;
     const $deprecated = TypeChecker.fromRuntime(Deprecated);
 
     expect(
@@ -232,17 +231,17 @@ void main() {
   });
 
   group('should find annotations', () {
-    TypeChecker $A;
-    TypeChecker $B;
-    TypeChecker $C;
+    late TypeChecker $A;
+    late TypeChecker $B;
+    late TypeChecker $C;
 
-    ClassElement $ExampleOfA;
-    ClassElement $ExampleOfMultiA;
-    ClassElement $ExampleOfAPlusB;
-    ClassElement $ExampleOfBPlusC;
+    late ClassElement $ExampleOfA;
+    late ClassElement $ExampleOfMultiA;
+    late ClassElement $ExampleOfAPlusB;
+    late ClassElement $ExampleOfBPlusC;
 
     setUpAll(() async {
-      final library = await resolveSource(r'''
+      final library = (await resolveSource(r'''
       library _test;
 
       @A()
@@ -271,59 +270,59 @@ void main() {
       class C extends B {
         const C();
       }
-    ''', (resolver) => resolver.findLibraryByName('_test'));
-      $A = TypeChecker.fromStatic(library.getType('A').instantiate(
+    ''', (resolver) => resolver.findLibraryByName('_test')))!;
+      $A = TypeChecker.fromStatic(library.getType('A')!.instantiate(
           typeArguments: [], nullabilitySuffix: NullabilitySuffix.none));
-      $B = TypeChecker.fromStatic(library.getType('B').instantiate(
+      $B = TypeChecker.fromStatic(library.getType('B')!.instantiate(
           typeArguments: [], nullabilitySuffix: NullabilitySuffix.none));
-      $C = TypeChecker.fromStatic(library.getType('C').instantiate(
+      $C = TypeChecker.fromStatic(library.getType('C')!.instantiate(
           typeArguments: [], nullabilitySuffix: NullabilitySuffix.none));
-      $ExampleOfA = library.getType('ExampleOfA');
-      $ExampleOfMultiA = library.getType('ExampleOfMultiA');
-      $ExampleOfAPlusB = library.getType('ExampleOfAPlusB');
-      $ExampleOfBPlusC = library.getType('ExampleOfBPlusC');
+      $ExampleOfA = library.getType('ExampleOfA')!;
+      $ExampleOfMultiA = library.getType('ExampleOfMultiA')!;
+      $ExampleOfAPlusB = library.getType('ExampleOfAPlusB')!;
+      $ExampleOfBPlusC = library.getType('ExampleOfBPlusC')!;
     });
 
     test('of a single @A', () {
       expect($A.hasAnnotationOf($ExampleOfA), isTrue);
-      final aAnnotation = $A.firstAnnotationOf($ExampleOfA);
-      expect(aAnnotation.type.element.name, 'A');
+      final aAnnotation = $A.firstAnnotationOf($ExampleOfA)!;
+      expect(aAnnotation.type!.element!.name, 'A');
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a multiple @A', () {
       final aAnnotations = $A.annotationsOf($ExampleOfMultiA);
-      expect(aAnnotations.map((a) => a.type.element.name), ['A', 'A']);
+      expect(aAnnotations.map((a) => a!.type!.element!.name), ['A', 'A']);
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a single @A + single @B', () {
       final aAnnotations = $A.annotationsOf($ExampleOfAPlusB);
-      expect(aAnnotations.map((a) => a.type.element.name), ['A']);
+      expect(aAnnotations.map((a) => a!.type!.element!.name), ['A']);
       final bAnnotations = $B.annotationsOf($ExampleOfAPlusB);
-      expect(bAnnotations.map((a) => a.type.element.name), ['B']);
+      expect(bAnnotations.map((a) => a!.type!.element!.name), ['B']);
       expect($C.annotationsOf($ExampleOfAPlusB), isEmpty);
     });
 
     test('of a single @B + single @C', () {
       final cAnnotations = $C.annotationsOf($ExampleOfBPlusC);
-      expect(cAnnotations.map((a) => a.type.element.name), ['C']);
+      expect(cAnnotations.map((a) => a!.type!.element!.name), ['C']);
       final bAnnotations = $B.annotationsOf($ExampleOfBPlusC);
-      expect(bAnnotations.map((a) => a.type.element.name), ['B', 'C']);
+      expect(bAnnotations.map((a) => a!.type!.element!.name), ['B', 'C']);
       expect($B.hasAnnotationOfExact($ExampleOfBPlusC), isTrue);
       final bExact = $B.annotationsOfExact($ExampleOfBPlusC);
-      expect(bExact.map((a) => a.type.element.name), ['B']);
+      expect(bExact.map((a) => a!.type!.element!.name), ['B']);
     });
   });
 
   group('unresolved annotations', () {
-    TypeChecker $A;
-    ClassElement $ExampleOfA;
+    late TypeChecker $A;
+    late ClassElement $ExampleOfA;
 
     setUpAll(() async {
-      final library = await resolveSource(r'''
+      final library = (await resolveSource(r'''
       library _test;
 
       // Put the missing annotation first so it throws.
@@ -334,10 +333,10 @@ void main() {
       class A {
         const A();
       }
-    ''', (resolver) => resolver.findLibraryByName('_test'));
-      $A = TypeChecker.fromStatic(library.getType('A').instantiate(
+    ''', (resolver) => resolver.findLibraryByName('_test')))!;
+      $A = TypeChecker.fromStatic(library.getType('A')!.instantiate(
           typeArguments: [], nullabilitySuffix: NullabilitySuffix.none));
-      $ExampleOfA = library.getType('ExampleOfA');
+      $ExampleOfA = library.getType('ExampleOfA')!;
     });
 
     test('should throw by default', () {
@@ -354,27 +353,27 @@ void main() {
     test('should not throw if `throwOnUnresolved` == false', () {
       expect(
           $A
-              .firstAnnotationOf($ExampleOfA, throwOnUnresolved: false)
-              .type
-              .element
+              .firstAnnotationOf($ExampleOfA, throwOnUnresolved: false)!
+              .type!
+              .element!
               .name,
           'A');
       expect(
           $A
               .annotationsOf($ExampleOfA, throwOnUnresolved: false)
-              .map((a) => a.type.element.name),
+              .map((a) => a!.type!.element!.name),
           ['A']);
       expect(
           $A
-              .firstAnnotationOfExact($ExampleOfA, throwOnUnresolved: false)
-              .type
-              .element
+              .firstAnnotationOfExact($ExampleOfA, throwOnUnresolved: false)!
+              .type!
+              .element!
               .name,
           'A');
       expect(
           $A
               .annotationsOfExact($ExampleOfA, throwOnUnresolved: false)
-              .map((a) => a.type.element.name),
+              .map((a) => a!.type!.element!.name),
           ['A']);
     });
   });

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -10,7 +10,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 void main() {
-  ClassElement example;
+  late ClassElement example;
 
   setUpAll(() async {
     const source = r'''
@@ -28,7 +28,7 @@ void main() {
         source,
         (resolver) => resolver
             .findLibraryByName('example')
-            .then((e) => e.getType('Example')));
+            .then((e) => e!.getType('Example')!));
   });
 
   test('should return the name of a class type', () {


### PR DESCRIPTION
Migrates `source_gen`, tests and the example.

Still blocked by

- ~~`build_config`, `build_runner_core` and `build_runner` not being released yet~~ :heavy_check_mark: 
- https://github.com/dart-lang/dart_style/pull/1000 (and that being published)

Closes #493