### PR TITLE
Prepare to publish for null safety

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-dev
+## 1.0.0
 
 * Migrate to null safety.
 * Drop deprecated APIs:

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.0.0-dev
+version: 1.0.0
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen
@@ -9,18 +9,17 @@ environment:
 
 dependencies:
   analyzer: ^1.1.0
-  async: ^2.0.7
+  async: ^2.5.0
   build: ^2.0.0
   dart_style: ^2.0.0
   glob: ^2.0.0
-  meta: ^1.1.0
-  path: ^1.3.2
-  pedantic: ^1.0.0
-  source_span: ^1.4.0
+  meta: ^1.3.0
+  path: ^1.8.0
+  pedantic: ^1.10.0
+  source_span: ^1.8.0
 
 dev_dependencies:
   _test_annotations:
     path: ../_test_annotations
   build_test: ^2.0.0
-  test: ^1.0.0
-
+  test: ^1.16.0


### PR DESCRIPTION
- Bump the min version of all deps to the null safe version.
- Drop the `-dev` suffix from the version.