### PR TITLE
Add two more '// ignore' comments for non-nullable LibraryElement.name

### DIFF
--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -42,7 +42,7 @@ String typeNameOf(DartType type) {
 /// Returns `null` if [element] is missing identifier.
 String nameOfPartial(LibraryElement element, AssetId source) {
   // TODO(scheglov) Remove when switched to newer package:analyzer.
-  // ignore:unnecessary_non_null_assertion
+  // ignore:unnecessary_non_null_assertion, unnecessary_null_comparison
   if (element.name != null && element.name!.isNotEmpty) {
     // ignore:unnecessary_non_null_assertion
     return element.name!;

--- a/source_gen/test/src/comment_generator.dart
+++ b/source_gen/test/src/comment_generator.dart
@@ -15,6 +15,8 @@ class CommentGenerator extends Generator {
   Future<String> generate(LibraryReader library, _) async {
     final output = <String>[];
     if (forLibrary) {
+      // TODO(scheglov) Remove when switched to newer package:analyzer.
+      // ignore:unnecessary_non_null_assertion
       var name = library.element.name!;
       if (name.isEmpty) {
         name = library.element.source.uri.pathSegments.last;


### PR DESCRIPTION
Unfortunately I missed one in the tests last time, found yesterday during global presubmit.