### PR TITLE
Update revive.dart to use type name instead of class name

### DIFF
--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -65,15 +65,16 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   }
 
   // ignore: deprecated_member_use
-  for (final e in origin!.definingCompilationUnit.types
-      .expand((t) => t.fields)
-      .where((f) => f.isConst && f.computeConstantValue() == object)) {
-    final result = Revivable._(
-      source: url.removeFragment(),
-      accessor: '${clazz.name}.${e.name}',
-    );
-    if (tryResult(result)) {
-      return result;
+  for (final type in origin!.definingCompilationUnit.types) {
+    for (final e in type.fields
+        .where((f) => f.isConst && f.computeConstantValue() == object)) {
+      final result = Revivable._(
+        source: url.removeFragment(),
+        accessor: '${type.name}.${e.name}',
+      );
+      if (tryResult(result)) {
+        return result;
+      }
     }
   }
   final i = (object as DartObjectImpl).getInvocation();

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -218,14 +218,22 @@ void main() {
         @Wrapper(_privateFunction)
         class Example {}
 
-        class Int64Like {
-          static const Int64Like ZERO = const Int64Like._bits(0, 0, 0);
+        class Int64Like implements Int64LikeBase{
+          static const Int64Like ZERO = const Int64LikeBase._bits(0, 0, 0);
 
           final int _l;
           final int _m;
           final int _h;
 
           const Int64Like._bits(this._l, this._m, this._h);
+        }
+
+        class Int64LikeBase {
+          final int _l;
+          final int _m;
+          final int _h;
+
+          const Int64LikeBase._bits(this._l, this._m, this._h);
         }
 
         enum Enum {


### PR DESCRIPTION
Updating source-gen to use type name instead of class name when generating parameter default values.
