### PR TITLE
auto-apply dartfmt fixes

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.2.2-dev
 
+* Enable the fix for single cascade statements when formatting Dart code.
+  * Individual builders can opt out of this by providing a custom `formatOutput`
+    function to the `PartBuilder` or `LibraryBuilder` constructors.
+
 ## 1.2.1
 
 - Allow reviving constants which are static fields defined on the class which

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -391,7 +391,7 @@ Future<bool> _hasAnyTopLevelAnnotations(
   return false;
 }
 
-final _formatter = DartFormatter(fixes: StyleFix.all);
+final _formatter = DartFormatter(fixes: [StyleFix.singleCascadeStatements]);
 
 const defaultFileHeader = '// GENERATED CODE - DO NOT MODIFY BY HAND';
 

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -391,7 +391,7 @@ Future<bool> _hasAnyTopLevelAnnotations(
   return false;
 }
 
-final _formatter = DartFormatter();
+final _formatter = DartFormatter(fixes: StyleFix.all);
 
 const defaultFileHeader = '// GENERATED CODE - DO NOT MODIFY BY HAND';
 

--- a/source_gen/test/src/unformatted_code_generator.dart
+++ b/source_gen/test/src/unformatted_code_generator.dart
@@ -13,9 +13,13 @@ class UnformattedCodeGenerator extends Generator {
 
   static const formattedCode = '''
 void hello() => print('hello');
+
+final obj = Object();
 ''';
 
   static const unformattedCode = '''
 void hello ()=>  print('hello');
+
+final obj = new Object();
 ''';
 }

--- a/source_gen/test/src/unformatted_code_generator.dart
+++ b/source_gen/test/src/unformatted_code_generator.dart
@@ -14,12 +14,16 @@ class UnformattedCodeGenerator extends Generator {
   static const formattedCode = '''
 void hello() => print('hello');
 
-final obj = Object();
+void x() {
+  <String>[].add('y');
+}
 ''';
 
   static const unformattedCode = '''
 void hello ()=>  print('hello');
 
-final obj = new Object();
+void x() {
+  <String>[]..add('y');
+}
 ''';
 }


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_gen/issues/551

I think this is pretty reasonable, especially since you can override the behavior.

@munificent are there any cases you know about where a fix would break code or all they all super safe?