### PR TITLE
Configurable outputs for the combining builder

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0-dev
+
+* Add the `build_extensions` option to `combining_builder`, allowing output
+  files to be generated into a different directory.
+
 ## 1.0.5
 
 * Fix a bug with reviving constant expressions which are fields defined on a

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0-dev
+## 1.1.0
 
 * Add the `build_extensions` option to `combining_builder`, allowing output
   files to be generated into a different directory.

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -117,6 +117,41 @@ targets:
 If you provide a builder that uses `SharedPartBuilder` and `combining_builder`,
 you should document this feature for your users.
 
+### Generating files in different directories
+
+When using shared-part builders which apply the `combining_builder` as part of
+the build, the output location for an input file can be changed.
+By default, a `.g.dart` file next to the input is generated.
+
+To change this, set the `build_extensions` option on the combining builder. In
+the options, `build_extensions` is a map from `String` to `String`, where the
+key is matches inputs and the value is a single build output.
+For more details on build extensions, see [the docs in the build package][outputs].
+
+For example, you can use these options to generate files under `lib/generated`
+with the following build configuration:
+
+```yaml
+targets:
+  $default:
+    builders:
+      source_gen|combining_builder:
+        options:
+          build_extensions:
+            '^lib/{{}}.dart': 'lib/generated/{{}}.g.dart'
+```
+
+Remember to change the `part` statement in the input to refer to the correct
+output file in the other directory.
+
+Note that builder options are part of `source_gen`'s public api! When using
+them in a build configuration, always add a dependency on `source_gen` as well:
+
+```yaml
+dev_dependencies:
+  source_gen: ^1.1.0
+```
+
 ## FAQ
 
 ### What is the difference between `source_gen` and [build][]?
@@ -148,3 +183,4 @@ wraps a single Generator to make a `Builder` which creates Dart library files.
 [Trivial example]: https://github.com/dart-lang/source_gen/blob/master/source_gen/test/src/comment_generator.dart
 [Full example package]: https://github.com/dart-lang/source_gen/tree/master/example
 [example usage]: https://github.com/dart-lang/source_gen/tree/master/example_usage
+[outputs]: https://github.com/dart-lang/build/blob/master/docs/writing_a_builder.md#configuring-outputs

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -21,7 +21,7 @@ import '../utils.dart';
 /// build tool(s) using this library to surface error messages to the user.
 Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   final objectType = object.type;
-  Element? element = objectType!.aliasElement;
+  Element? element = objectType!.alias?.element;
   if (element == null) {
     if (objectType is InterfaceType) {
       element = objectType.element;

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -302,7 +302,7 @@ class UnresolvedAnnotationException implements Exception {
   ) {
     try {
       final parsedLibrary = annotatedElement.session!
-              .getParsedLibraryByElement2(annotatedElement.library!)
+              .getParsedLibraryByElement(annotatedElement.library!)
           as ParsedLibraryResult;
       final declaration = parsedLibrary.getElementDeclaration(annotatedElement);
       if (declaration == null) {

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -22,7 +22,7 @@ import 'package:yaml/yaml.dart';
 ///
 /// This function will return `'VoidFunc'`, unlike [DartType.element.name].
 String typeNameOf(DartType type) {
-  final aliasElement = type.aliasElement;
+  final aliasElement = type.alias?.element;
   if (aliasElement != null) {
     return aliasElement.name;
   }

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
@@ -37,14 +38,21 @@ String typeNameOf(DartType type) {
   throw UnimplementedError('(${type.runtimeType}) $type');
 }
 
+bool hasExpectedPartDirective(CompilationUnit unit, String part) =>
+    unit.directives
+        .whereType<PartDirective>()
+        .any((e) => e.uri.stringValue == part);
+
 /// Returns a name suitable for `part of "..."` when pointing to [element].
-String nameOfPartial(LibraryElement element, AssetId source) {
+String nameOfPartial(LibraryElement element, AssetId source, AssetId output) {
   if (element.name.isNotEmpty) {
     return element.name;
   }
 
-  final sourceUrl = p.basename(source.uri.toString());
-  return '\'$sourceUrl\'';
+  assert(source.package == output.package);
+  final relativeSourceUri =
+      p.url.relative(source.path, from: p.dirname(output.path));
+  return '\'$relativeSourceUri\'';
 }
 
 /// Returns a suggested library identifier based on [source] path and package.

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^2.0.0
+  analyzer: ^2.1.0
   async: ^2.5.0
   build: ^2.1.0
   dart_style: ^2.0.0

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.0.5
+version: 1.1.0-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ^2.0.0
   async: ^2.5.0
-  build: ^2.0.0
+  build: ^2.1.0
   dart_style: ^2.0.0
   glob: ^2.0.0
   meta: ^1.3.0

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.1.0-dev
+version: 1.1.0
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
This adds support for custom output locations, including outputs in different directories, to the combining builder.

- Make output extensions configurable through builder options. The options are validated to ensure the combining builder is running on Dart files and emits Dart files
- Move the check ensuring we have a `part` statement from the `SharedPartBuilder` to the `CombiningBuilder`. The former can't know the correct output location anymore.

This is related to #272, where the implementation in `build` requires cooperation from builders. Given that most generated files come from shared part generators in practice, this would enable generating to different folders for most users.