### PR TITLE
Stub test generator behavior within tests

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.2-dev
+
 ## 1.1.1
 
 - Drop dependency on `package:pedantic`.

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.1.1
+version: 1.1.2-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
Remove some individual implementations of `Generator` and
`GeneratorForAnnotation` in tests in favor of a general `_StubGenerator`
implementation which can take a callback for it's behavior. This keeps
the interesting behavior for the test contained within the test.

Move the test for `GeneratorForAnnotation` not resolving libraries which
have no annotated elements into the relevant test suite.