### PR TITLE
Include the library in LibraryReader.allElements

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.1.2-dev
 
+- Include the `LibraryElement` in `LibraryReader.allElements`,
+  `LibraryReader.annotatedWith`, and `LibraryReader.annotatedWithExact`. Run
+  `GeneratorForAnnotation` generators on library elements when the `library`
+  statement has the annotation.
+
 ## 1.1.1
 
 - Drop dependency on `package:pedantic`.

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -34,7 +34,7 @@ class LibraryReader {
   }
 
   /// All of the declarations in this library.
-  Iterable<Element> get allElements => element.topLevelElements;
+  Iterable<Element> get allElements => [element, ...element.topLevelElements];
 
   /// All of the declarations in this library annotated with [checker].
   Iterable<AnnotatedElement> annotatedWith(TypeChecker checker,

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.1.2-dev
+version: 1.2.0-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -98,6 +98,28 @@ void main() {
     expect(resolver.parsedUnits, {input});
     expect(resolver.resolvedLibs, isEmpty);
   });
+
+  test('applies to annotated libraries', () async {
+    final builder = LibraryBuilder(_StubGenerator<Deprecated>(
+        'Deprecated',
+        (element) => '// ${element.displayName}'));
+    await testBuilder(builder, {
+      'a|lib/file.dart': '''
+      @deprecated
+      library foo;
+      '''
+    }, outputs: {
+      'a|lib/file.g.dart': '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// Generator: Deprecated
+// **************************************************************************
+
+// foo
+'''
+    });
+  });
 }
 
 class _StubGenerator<T> extends GeneratorForAnnotation<T> {

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -101,8 +101,7 @@ void main() {
 
   test('applies to annotated libraries', () async {
     final builder = LibraryBuilder(_StubGenerator<Deprecated>(
-        'Deprecated',
-        (element) => '// ${element.displayName}'));
+        'Deprecated', (element) => '// ${element.displayName}'));
     await testBuilder(builder, {
       'a|lib/file.dart': '''
       @deprecated


### PR DESCRIPTION
Fixes #558

`GeneratorForAnnotation` uses `annotatedWith` which uses `allElements`
to search for annotated elements within a library. When the annotation
was applied on a `library` statement it would appear on the
`LibraryElement` which is not included in `topLevelElements` so the
annotation was ignored.

This is a visible behavior change, but since `allElements` could already
have an arbitrary number and types of elements it's unlikely some
implementation is specifically relying on the _absence_ of any given
element, including the library.