### PR TITLE
Configurable outputs for the PartBuilder

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -4,6 +4,9 @@
   `LibraryReader.annotatedWith`, and `LibraryReader.annotatedWithExact`. Run
   `GeneratorForAnnotation` generators on library elements when the `library`
   statement has the annotation.
+- Add support for `build_extensions` configuration to the `PartBuilder` and
+  `LibraryBuilder`. You must forward the `BuilderOptions` object to the super
+  constructor for this to work.
 
 ## 1.1.1
 

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -119,11 +119,13 @@ you should document this feature for your users.
 
 ### Generating files in different directories
 
-When using shared-part builders which apply the `combining_builder` as part of
-the build, the output location for an input file can be changed.
-By default, a `.g.dart` file next to the input is generated.
+The output location for an input file can be changed:
+- when using `PartBuilder`,
+- when using `SharedPartBuilder` which apply the `combining_builder` as part of
+the build,
 
-To change this, set the `build_extensions` option on the combining builder. In
+By default, a `.g.dart` or `.some_name.dart` file is generated next to the input.
+To change this, set the `build_extensions` option on the corresponding builder. In
 the options, `build_extensions` is a map from `String` to `String`, where the
 key is matches inputs and the value is a single build output.
 For more details on build extensions, see [the docs in the build package][outputs].
@@ -139,6 +141,11 @@ targets:
         options:
           build_extensions:
             '^lib/{{}}.dart': 'lib/generated/{{}}.g.dart'
+
+      some_cool_builder:
+        options:
+          build_extensions:
+            '^lib/models/{{}}.dart': 'lib/models/generated/{{}}.foo.dart'
 ```
 
 Remember to change the `part` statement in the input to refer to the correct

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -137,11 +137,13 @@ with the following build configuration:
 targets:
   $default:
     builders:
+      # A SharedPartBuilder which uses the combining builder
       source_gen|combining_builder:
         options:
           build_extensions:
             '^lib/{{}}.dart': 'lib/generated/{{}}.g.dart'
 
+      # A PartBuilder or LibraryBuilder
       some_cool_builder:
         options:
           build_extensions:

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -121,8 +121,8 @@ you should document this feature for your users.
 
 The output location for an input file can be changed:
 - when using `PartBuilder` or `LibraryBuilder`.
-- when using `SharedPartBuilder` which apply the `combining_builder` as part of
-the build,
+- when using `SharedPartBuilder` which apply the `combining_builder` as
+part of the build.
 
 By default, a `.g.dart` or `.some_name.dart` file is generated next to the input.
 To change this, set the `build_extensions` option on the corresponding builder. In

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -120,7 +120,7 @@ you should document this feature for your users.
 ### Generating files in different directories
 
 The output location for an input file can be changed:
-- when using `PartBuilder`,
+- when using `PartBuilder` or `LibraryBuilder`.
 - when using `SharedPartBuilder` which apply the `combining_builder` as part of
 the build,
 

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -32,7 +32,8 @@ Builder combiningBuilder([BuilderOptions options = BuilderOptions.empty]) {
   final ignoreForFile = Set<String>.from(
     optionsMap.remove('ignore_for_file') as List? ?? <String>[],
   );
-  final buildExtensions = _validatedBuildExtensionsFrom(optionsMap);
+  final buildExtensions =
+      validatedBuildExtensionsFrom(optionsMap, _defaultExtensions);
 
   final builder = CombiningBuilder(
     includePartName: includePartName,
@@ -44,41 +45,6 @@ Builder combiningBuilder([BuilderOptions options = BuilderOptions.empty]) {
     log.warning('These options were ignored: `$optionsMap`.');
   }
   return builder;
-}
-
-Map<String, List<String>> _validatedBuildExtensionsFrom(
-    Map<String, dynamic> optionsMap) {
-  final extensionsOption = optionsMap.remove('build_extensions');
-  if (extensionsOption == null) return _defaultExtensions;
-
-  if (extensionsOption is! Map) {
-    throw ArgumentError(
-        'Configured build_extensions should be a map from inputs to outputs.');
-  }
-
-  final result = <String, List<String>>{};
-
-  for (final entry in extensionsOption.entries) {
-    final input = entry.key;
-    if (input is! String || !input.endsWith('.dart')) {
-      throw ArgumentError('Invalid key in build_extensions option: `$input` '
-          'should be a string ending with `.dart`');
-    }
-
-    final output = entry.value;
-    if (output is! String || !output.endsWith('.dart')) {
-      throw ArgumentError('Invalid output extension `$output`. It should be a '
-          'string ending with `.dart`');
-    }
-
-    result[input] = [output];
-  }
-
-  if (result.isEmpty) {
-    throw ArgumentError('Configured build_extensions must not be empty.');
-  }
-
-  return result;
 }
 
 PostProcessBuilder partCleanup(BuilderOptions options) =>

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -48,9 +48,10 @@ class _Builder extends Builder {
     List<String> additionalOutputExtensions = const [],
     String? header,
     this.allowSyntaxErrors = false,
-    BuilderOptions options = BuilderOptions.empty,
+    BuilderOptions? options,
   })  : _generatedExtension = generatedExtension,
-        buildExtensions = validatedBuildExtensionsFrom(Map.of(options.config), {
+        buildExtensions = validatedBuildExtensionsFrom(
+            options != null ? Map.of(options.config) : null, {
           '.dart': [
             generatedExtension,
             ...additionalOutputExtensions,
@@ -66,8 +67,7 @@ class _Builder extends Builder {
       throw ArgumentError(
           'A standalone file can only be generated from a single Generator.');
     }
-    if (options != BuilderOptions.empty &&
-        additionalOutputExtensions.isNotEmpty) {
+    if (options != null && additionalOutputExtensions.isNotEmpty) {
       throw ArgumentError(
           'Either `options` or `additionalOutputExtensions` parameter '
           'can be given. Not both.');
@@ -270,7 +270,7 @@ class PartBuilder extends _Builder {
     List<String> additionalOutputExtensions = const [],
     String? header,
     bool allowSyntaxErrors = false,
-    BuilderOptions options = BuilderOptions.empty,
+    BuilderOptions? options,
   }) : super(
           generators,
           formatOutput: formatOutput,
@@ -313,7 +313,7 @@ class LibraryBuilder extends _Builder {
     List<String> additionalOutputExtensions = const [],
     String? header,
     bool allowSyntaxErrors = false,
-    BuilderOptions options = BuilderOptions.empty,
+    BuilderOptions? options,
   }) : super(
           [generator],
           formatOutput: formatOutput,

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -35,7 +35,7 @@ class _Builder extends Builder {
   final bool allowSyntaxErrors;
 
   @override
-  late final Map<String, List<String>> buildExtensions;
+  final Map<String, List<String>> buildExtensions;
 
   /// Wrap [_generators] to form a [Builder]-compatible API.
   ///
@@ -50,6 +50,12 @@ class _Builder extends Builder {
     this.allowSyntaxErrors = false,
     BuilderOptions options = BuilderOptions.empty,
   })  : _generatedExtension = generatedExtension,
+        buildExtensions = validatedBuildExtensionsFrom(Map.of(options.config), {
+          '.dart': [
+            generatedExtension,
+            ...additionalOutputExtensions,
+          ]
+        }),
         formatOutput = formatOutput ?? _formatter.format,
         _header = (header ?? defaultFileHeader).trim() {
     if (_generatedExtension.isEmpty || !_generatedExtension.startsWith('.')) {
@@ -60,16 +66,6 @@ class _Builder extends Builder {
       throw ArgumentError(
           'A standalone file can only be generated from a single Generator.');
     }
-    
-    final optionsMap = Map<String, dynamic>.from(options.config);
-    final defaultBuildExtensions = {
-      '.dart': [
-        generatedExtension,
-        ...additionalOutputExtensions,
-      ]
-    };
-    buildExtensions =
-        validatedBuildExtensionsFrom(optionsMap, defaultBuildExtensions);
   }
 
   @override

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -40,7 +40,7 @@ class _Builder extends Builder {
   /// Wrap [_generators] to form a [Builder]-compatible API.
   ///
   /// If available, the `build_extensions` option will be extracted from
-  /// [options] to allow output files to be generated into a different directory.
+  /// [options] to allow output files to be generated into a different directory
   _Builder(
     this._generators, {
     String Function(String code)? formatOutput,

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -66,6 +66,12 @@ class _Builder extends Builder {
       throw ArgumentError(
           'A standalone file can only be generated from a single Generator.');
     }
+    if (options != BuilderOptions.empty &&
+        additionalOutputExtensions.isNotEmpty) {
+      throw ArgumentError(
+          'Either `options` or `additionalOutputExtensions` parameter '
+          'can be given. Not both.');
+    }
   }
 
   @override

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -102,7 +102,7 @@ class _Builder extends Builder {
     // library/part definitions because users expect some files to be skipped
     // therefore they do not have "library".
     if (generatedOutputs.isEmpty) return;
-    final outputId = buildStep.allowedOutputs.single;
+    final outputId = buildStep.allowedOutputs.first;
     final contentBuffer = StringBuffer();
 
     if (_header.isNotEmpty) {

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -256,7 +256,7 @@ class PartBuilder extends _Builder {
   /// libraries.
   ///
   /// If available, the `build_extensions` option will be extracted from
-  /// [options] to allow output files to be generated into a different directory.
+  /// [options] to allow output files to be generated into a different directory
   PartBuilder(
     List<Generator> generators,
     String generatedExtension, {

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -307,6 +307,7 @@ class LibraryBuilder extends _Builder {
     List<String> additionalOutputExtensions = const [],
     String? header,
     bool allowSyntaxErrors = false,
+    BuilderOptions options = BuilderOptions.empty,
   }) : super(
           [generator],
           formatOutput: formatOutput,
@@ -314,6 +315,7 @@ class LibraryBuilder extends _Builder {
           additionalOutputExtensions: additionalOutputExtensions,
           header: header,
           allowSyntaxErrors: allowSyntaxErrors,
+          options: options,
         );
 }
 

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -161,6 +161,9 @@ final String rootPackageName = () {
 
 /// Returns a valid buildExtensions map created from [optionsMap] or
 /// returns [defaultExtensions] if no 'build_extensions' key exists.
+///
+/// Modifies [optionsMap] by removing the `build_extensions` key from it, if
+/// present.
 Map<String, List<String>> validatedBuildExtensionsFrom(
     Map<String, dynamic> optionsMap,
     Map<String, List<String>> defaultExtensions) {

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -165,9 +165,9 @@ final String rootPackageName = () {
 /// Modifies [optionsMap] by removing the `build_extensions` key from it, if
 /// present.
 Map<String, List<String>> validatedBuildExtensionsFrom(
-    Map<String, dynamic> optionsMap,
+    Map<String, dynamic>? optionsMap,
     Map<String, List<String>> defaultExtensions) {
-  final extensionsOption = optionsMap.remove('build_extensions');
+  final extensionsOption = optionsMap?.remove('build_extensions');
   if (extensionsOption == null) return defaultExtensions;
 
   if (extensionsOption is! Map) {

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -158,3 +158,41 @@ final String rootPackageName = () {
   }
   return name;
 }();
+
+/// Returns a valid buildExtensions map created from [optionsMap] or
+/// returns [defaultExtensions] if no 'build_extensions' key exists.
+Map<String, List<String>> validatedBuildExtensionsFrom(
+    Map<String, dynamic> optionsMap,
+    Map<String, List<String>> defaultExtensions) {
+  final extensionsOption = optionsMap.remove('build_extensions');
+  if (extensionsOption == null) return defaultExtensions;
+
+  if (extensionsOption is! Map) {
+    throw ArgumentError(
+        'Configured build_extensions should be a map from inputs to outputs.');
+  }
+
+  final result = <String, List<String>>{};
+
+  for (final entry in extensionsOption.entries) {
+    final input = entry.key;
+    if (input is! String || !input.endsWith('.dart')) {
+      throw ArgumentError('Invalid key in build_extensions option: `$input` '
+          'should be a string ending with `.dart`');
+    }
+
+    final output = entry.value;
+    if (output is! String || !output.endsWith('.dart')) {
+      throw ArgumentError('Invalid output extension `$output`. It should be a '
+          'string ending with `.dart`');
+    }
+
+    result[input] = [output];
+  }
+
+  if (result.isEmpty) {
+    throw ArgumentError('Configured build_extensions must not be empty.');
+  }
+
+  return result;
+}

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -344,6 +344,31 @@ part "a.foo.dart";'''
     });
   });
 
+  group('LibraryBuilder', () {
+    group('with build_extensions', () {
+      test('generates relative `path of` for output in different directory',
+          () async {
+        await testBuilder(
+            LibraryBuilder(
+              const CommentGenerator(),
+              options: const BuilderOptions({
+                'build_extensions': {
+                  '^lib/{{}}.dart': 'lib/generated/{{}}.g.dart'
+                }
+              }),
+            ),
+            _createPackageStub(),
+            generateFor: {
+              '$_pkgName|lib/test_lib.dart'
+            },
+            outputs: {
+              '$_pkgName|lib/generated/test_lib.g.dart':
+                  _testGenStandaloneContent,
+            });
+      });
+    });
+  });
+
   group('SharedPartBuilder', () {
     test('outputs <partId>.g.part files', () async {
       await testBuilder(

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -367,8 +367,7 @@ part "a.foo.dart";'''
 
   group('LibraryBuilder', () {
     group('with build_extensions', () {
-      test('outputs to the correct location',
-          () async {
+      test('outputs to the correct location', () async {
         await testBuilder(
             LibraryBuilder(
               const CommentGenerator(),

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -341,6 +341,27 @@ part "a.foo.dart";'''
                   decodedMatches(startsWith("part of '../a.dart';")),
             });
       });
+
+      test(
+          'throws if `options` and `additionalOutputExtensions` are both given',
+          () async {
+        await expectLater(
+          () => testBuilder(
+            PartBuilder(
+              [const UnformattedCodeGenerator()],
+              '.foo.dart',
+              additionalOutputExtensions: ['.bar.dart'],
+              options: const BuilderOptions({
+                'build_extensions': {
+                  '^lib/{{}}.dart': 'lib/generated/{{}}.foo.dart'
+                }
+              }),
+            ),
+            {'$_pkgName|lib/a.dart': 'part "generated/a.foo.dart";'},
+          ),
+          throwsArgumentError,
+        );
+      });
     });
   });
 
@@ -365,6 +386,26 @@ part "a.foo.dart";'''
               '$_pkgName|lib/generated/test_lib.g.dart':
                   _testGenStandaloneContent,
             });
+      });
+
+      test(
+          'throws if `options` and `additionalOutputExtensions` are both given',
+          () async {
+        await expectLater(
+          () => testBuilder(
+            LibraryBuilder(
+              const CommentGenerator(),
+              additionalOutputExtensions: ['.foo.dart'],
+              options: const BuilderOptions({
+                'build_extensions': {
+                  '^lib/{{}}.dart': 'lib/generated/{{}}.foo.dart'
+                }
+              }),
+            ),
+            {'$_pkgName|lib/a.dart': 'part "generated/a.foo.dart";'},
+          ),
+          throwsArgumentError,
+        );
       });
     });
   });

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -346,7 +346,7 @@ part "a.foo.dart";'''
 
   group('LibraryBuilder', () {
     group('with build_extensions', () {
-      test('generates relative `path of` for output in different directory',
+      test('outputs to the correct location',
           () async {
         await testBuilder(
             LibraryBuilder(

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -229,7 +229,7 @@ void main() {
   });
 
   group('PartBuilder', () {
-    test('PartBuilder uses a custom header when provided', () async {
+    test('uses a custom header when provided', () async {
       await testBuilder(
           PartBuilder([const UnformattedCodeGenerator()], '.foo.dart',
               header: _customHeader),
@@ -245,7 +245,7 @@ void main() {
           });
     });
 
-    test('PartBuilder includes no header when `header` is empty', () async {
+    test('includes no header when `header` is empty', () async {
       await testBuilder(
           PartBuilder([const UnformattedCodeGenerator()], '.foo.dart',
               header: ''),
@@ -260,7 +260,7 @@ void main() {
           });
     });
 
-    test('PartBuilder includes matching language version in all parts', () async {
+    test('includes matching language version in all parts', () async {
       await testBuilder(
           PartBuilder([const UnformattedCodeGenerator()], '.foo.dart',
               header: ''),
@@ -277,7 +277,7 @@ part "a.foo.dart";'''
           });
     });
 
-    test('PartBuilder warns about missing part', () async {
+    test('warns about missing part', () async {
       final srcs = _createPackageStub(testLibContent: _testLibContentNoPart);
       final builder = PartBuilder([const CommentGenerator()], '.foo.dart');
       final logs = <String>[];
@@ -294,8 +294,8 @@ part "a.foo.dart";'''
       ]);
     });
 
-    group('PartBuilder with build_extensions', () {
-      test('PartBuilder (BE) warns about missing part', () async {
+    group('with build_extensions', () {
+      test('warns about missing part', () async {
         final srcs = _createPackageStub(testLibContent: _testLibContentNoPart);
         final builder = PartBuilder([const CommentGenerator()], '.foo.dart',
             options: const BuilderOptions({
@@ -317,7 +317,7 @@ part "a.foo.dart";'''
         ]);
       });
 
-      test('PartBuilder (BE) generates relative `path of` for output in different directory',
+      test('generates relative `path of` for output in different directory',
           () async {
         await testBuilder(
             PartBuilder(

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -6,7 +6,6 @@
 @Timeout.factor(2.0)
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build_test/build_test.dart';
-import 'package:source_gen/source_gen.dart';
 import 'package:source_gen/src/utils.dart';
 import 'package:test/test.dart';
 

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -7,6 +7,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/source_gen.dart';
+import 'package:source_gen/src/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -39,5 +40,64 @@ void main() {
   test('should return the name of a function type', () {
     final functionType = example.methods.last.returnType;
     expect(typeNameOf(functionType), 'FunctionType');
+  });
+
+  group('validatedBuildExtensionsFrom', () {
+    test('no option given -> return defaultBuildExtension ', () {
+      final buildEtension = validatedBuildExtensionsFrom({}, {
+        '.dart': ['.foo.dart'],
+      });
+      expect(buildEtension, {
+        '.dart': ['.foo.dart'],
+      });
+    });
+
+    test("disallows options that aren't a map", () {
+      expect(
+        () => validatedBuildExtensionsFrom({'build_extensions': 'foo'}, {}),
+        throwsArgumentError,
+      );
+    });
+
+    test('disallows empty options', () {
+      expect(
+        () => validatedBuildExtensionsFrom({'build_extensions': {}}, {}),
+        throwsArgumentError,
+      );
+    });
+
+    test('disallows inputs not ending with .dart', () {
+      expect(
+        () => validatedBuildExtensionsFrom({
+          'build_extensions': {
+            '.txt': ['.dart']
+          }
+        }, {}),
+        throwsA(
+          isArgumentError.having(
+            (e) => e.message,
+            'message',
+            'Invalid key in build_extensions option: `.txt` should be a '
+                'string ending with `.dart`',
+          ),
+        ),
+      );
+    });
+
+    test('disallows outputs not ending with .dart', () {
+      expect(
+        () => validatedBuildExtensionsFrom({
+          'build_extensions': {'.dart': '.out'}
+        }, {}),
+        throwsA(
+          isArgumentError.having(
+            (e) => e.message,
+            'message',
+            'Invalid output extension `.out`. It should be a string ending '
+                'with `.dart`',
+          ),
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
This adds support for custom output locations, including outputs in different directories, to the PartBuilder.

- Make output extensions configurable through builder options. The options are validated to ensure the PartBuilder is running on Dart files and emits Dart files (re-use existing validatedBuildExtensionsFrom)

This was done previously for the combining builder (https://github.com/dart-lang/source_gen/pull/554). This PR is for PartBuilder.

I've added some tests. All tests are passing. But as I'm not an expert of source_gen code, could you please review carefully this PR, especially :

file: source_gen/lib/src/builder.dart
new line:
`final outputId = buildStep.allowedOutputs.single;`
replacing:
`final outputId = buildStep.inputId.changeExtension(_generatedExtension);`
