### PR TITLE
Handle source spans on annotated parameters

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add support for `build_extensions` configuration to the `PartBuilder` and
   `LibraryBuilder`. You must forward the `BuilderOptions` object to the super
   constructor for this to work.
+- Fix a bug finding source locations for reporting unresolved annotations on
+  parameters.
 
 ## 1.1.1
 

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -308,8 +308,17 @@ class UnresolvedAnnotationException implements Exception {
       if (declaration == null) {
         return null;
       }
-      final annotatedNode = declaration.node as AnnotatedNode;
-      final annotation = annotatedNode.metadata[annotationIndex];
+      final node = declaration.node;
+      final List<Annotation> metadata;
+      if (node is AnnotatedNode) {
+        metadata = node.metadata;
+      } else if (node is FormalParameter) {
+        metadata = node.metadata;
+      } else {
+        throw StateError(
+            'Unhandled Annotated AST node type: ${node.runtimeType}');
+      }
+      final annotation = metadata[annotationIndex];
       final start = annotation.offset;
       final end = start + annotation.length;
       final parsedUnit = declaration.parsedUnit!;

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -339,6 +339,7 @@ void main() {
   group('unresolved annotations', () {
     late TypeChecker $A;
     late ClassElement $ExampleOfA;
+    late ParameterElement $annotatedParameter;
 
     setUpAll(() async {
       final library = await resolveSource(
@@ -350,6 +351,8 @@ void main() {
       @A()
       class ExampleOfA {}
 
+      void annotatedParameter(@B() @A() String parameter) {}
+
       class A {
         const A();
       }
@@ -359,6 +362,11 @@ void main() {
       $A = TypeChecker.fromStatic(library.getType('A')!.instantiate(
           typeArguments: [], nullabilitySuffix: NullabilitySuffix.none));
       $ExampleOfA = library.getType('ExampleOfA')!;
+      $annotatedParameter = library.topLevelElements
+          .whereType<FunctionElement>()
+          .firstWhere((f) => f.name == 'annotatedParameter')
+          .parameters
+          .single;
     });
 
     test('should throw by default', () {
@@ -369,6 +377,14 @@ void main() {
       expect(() => $A.firstAnnotationOfExact($ExampleOfA),
           throwsUnresolvedAnnotationException);
       expect(() => $A.annotationsOfExact($ExampleOfA),
+          throwsUnresolvedAnnotationException);
+      expect(() => $A.firstAnnotationOf($annotatedParameter),
+          throwsUnresolvedAnnotationException);
+      expect(() => $A.annotationsOf($annotatedParameter),
+          throwsUnresolvedAnnotationException);
+      expect(() => $A.firstAnnotationOfExact($annotatedParameter),
+          throwsUnresolvedAnnotationException);
+      expect(() => $A.annotationsOfExact($annotatedParameter),
           throwsUnresolvedAnnotationException);
     });
 
@@ -401,5 +417,6 @@ void main() {
   });
 }
 
-final throwsUnresolvedAnnotationException =
-    throwsA(const TypeMatcher<UnresolvedAnnotationException>());
+final throwsUnresolvedAnnotationException = throwsA(
+    const TypeMatcher<UnresolvedAnnotationException>()
+        .having((e) => e.annotationSource, 'annotationSource', isNotNull));


### PR DESCRIPTION
When we attempt to add context for errors relating to an annotation we
made the assumption that the declaration AstNode for the element would
always be an AnnotatedNode, however the class model has an unrelated
`metadata` field on `FormalParameter`.

Expand the checks in the test to validate the source span is found for
the exceptions.

Add tests for the exceptions produced for unresolved annotations on
parameters.