### PR TITLE
Improve missing part handling on Windows

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -9,6 +9,7 @@
   constructor for this to work.
 - Fix a bug finding source locations for reporting unresolved annotations on
   parameters.
+- Fix a bug checking for `part` statements on Windows.
 
 ## 1.1.1
 

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
-import 'package:path/path.dart' as p show url;
+import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 /// Returns a non-null name for the provided [type].
@@ -106,10 +106,9 @@ Uri normalizeDartUrl(Uri url) => url.pathSegments.isNotEmpty
     : url;
 
 Uri fileToAssetUrl(Uri url) {
-  if (!p.url.isWithin(p.url.current, url.path)) return url;
+  if (!p.isWithin(p.url.current, url.path)) return url;
   return Uri(
-      scheme: 'asset',
-      path: p.url.join(rootPackageName, p.url.relative(url.path)));
+      scheme: 'asset', path: p.join(rootPackageName, p.relative(url.path)));
 }
 
 /// Returns a `package:` URL converted to a `asset:` URL.

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
-import 'package:path/path.dart' as p;
+import 'package:path/path.dart' as p show url;
 import 'package:yaml/yaml.dart';
 
 /// Returns a non-null name for the provided [type].
@@ -51,7 +51,7 @@ String nameOfPartial(LibraryElement element, AssetId source, AssetId output) {
 
   assert(source.package == output.package);
   final relativeSourceUri =
-      p.url.relative(source.path, from: p.dirname(output.path));
+      p.url.relative(source.path, from: p.url.dirname(output.path));
   return '\'$relativeSourceUri\'';
 }
 
@@ -71,8 +71,8 @@ String suggestLibraryName(AssetId source) {
 /// Returns what 'part "..."' URL is needed to import [output] from [input].
 ///
 /// For example, will return `test_lib.g.dart` for `test_lib.dart`.
-String computePartUrl(AssetId input, AssetId output) =>
-    p.joinAll(p.split(p.relative(output.path, from: input.path)).skip(1));
+String computePartUrl(AssetId input, AssetId output) => p.url.joinAll(
+    p.url.split(p.url.relative(output.path, from: input.path)).skip(1));
 
 /// Returns a URL representing [element].
 String urlOfElement(Element element) => element.kind == ElementKind.DYNAMIC
@@ -106,9 +106,10 @@ Uri normalizeDartUrl(Uri url) => url.pathSegments.isNotEmpty
     : url;
 
 Uri fileToAssetUrl(Uri url) {
-  if (!p.isWithin(p.current, url.path)) return url;
+  if (!p.url.isWithin(p.url.current, url.path)) return url;
   return Uri(
-      scheme: 'asset', path: p.join(rootPackageName, p.relative(url.path)));
+      scheme: 'asset',
+      path: p.url.join(rootPackageName, p.url.relative(url.path)));
 }
 
 /// Returns a `package:` URL converted to a `asset:` URL.

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -315,8 +315,6 @@ part "a.foo.dart";'''
           'generated/test_lib.foo.dart must be included as a part directive in the input '
               'library with:\n    part \'generated/test_lib.foo.dart\';'
         ]);
-      }, onPlatform: const {
-        'windows': Skip('https://github.com/dart-lang/source_gen/issues/570')
       });
 
       test('generates relative `path of` for output in different directory',
@@ -342,8 +340,6 @@ part "a.foo.dart";'''
               '$_pkgName|lib/generated/a.foo.dart':
                   decodedMatches(startsWith("part of '../a.dart';")),
             });
-      }, onPlatform: const {
-        'windows': Skip('https://github.com/dart-lang/source_gen/issues/570')
       });
 
       test(
@@ -672,8 +668,6 @@ foo generated content
 ''')),
           },
         );
-      }, onPlatform: const {
-        'windows': Skip('https://github.com/dart-lang/source_gen/issues/570')
       });
 
       test('warns about missing part statement', () async {
@@ -698,8 +692,6 @@ foo generated content
             'input library with:\n    part \'generated/a.g.dart\';',
           ),
         );
-      }, onPlatform: const {
-        'windows': Skip('https://github.com/dart-lang/source_gen/issues/570')
       });
     });
   });


### PR DESCRIPTION
The combining part builder checks for the existence of a `part` statement in the source file, ensuring that generated code is included properly.

To do this, it computes the relative path of the configured output and the input asset using the `path` library. However, it uses the platform-specific default path context, even though Dart imports always use an URL-based context. This is not a problem if the input and the output are in the same directory, or if the native system uses a forward slash as a path separator. When using custom build extensions putting generated files in a different directory, this turns out to be a problem on Windows.

This PR ensures a consistent checking mechanism by always using the URL context. Fixes #570.

I'm not sure how to test this properly. Ideally we should run the CI on Windows too I guess, but I haven't looked into how this could be done with `mono_repo`.