### PR TITLE
Add a note about not importable annotations

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.1-dev
+
 ## 1.2.0
 
 - Include the `LibraryElement` in `LibraryReader.allElements`,

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -39,7 +39,14 @@ import 'type_checker.dart';
 /// extension, are not searched for annotations. To operate on, for instance,
 /// annotated fields of a class ensure that the class itself is annotated with
 /// [T] and use the [Element] to iterate over fields. The [TypeChecker] utility
-/// may be helpful to check which elements have a given annotation.
+/// may be helpful to check which elements have a given annotation if the
+/// generator should further filter it's target based on annotations.
+///
+/// If the annotation type cannot be imported on the Dart VM, for example if it
+/// imports `dart:html` or `dart:ui`, then the default behavior of using
+/// `TypeChecker.fromRuntime` is not feasible. In these cases extend
+/// `GeneratorForAnnotation<void>` and override the [typeChecker] member with a
+/// checker matching the annotation type.
 abstract class GeneratorForAnnotation<T> extends Generator {
   const GeneratorForAnnotation();
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.0
+version: 1.2.1-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
The build systems run on the Dart VM only, so there are limitations on
what imports can be used by builders. Add documentation describing how
to work around this limitation by overriding the `TypeChecker` with
something other than `fromRuntime`.