### PR TITLE
reviving: Prefer static constant fields on constant object's class

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1-dev
+
+- Allow reviving constants which are static fields defined on the class which
+  represents their type. Previously we checked this pattern only for enums,
+  however there are enum-like usages in classes which are not enums.
+
 ## 1.2.0
 
 - Include the `LibraryElement` in `LibraryReader.allElements`,

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -43,14 +43,13 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
       accessor: '${element.enclosingElement.name}.${element.name}',
     );
   }
-  // Enums are not included in .definingCompilationUnit.types.
-  final clazz = element as ClassElement;
-  if (clazz.isEnum) {
-    for (final e in clazz.fields.where(
+
+  if (element is ClassElement) {
+    for (final e in element.fields.where(
         (f) => f.isPublic && f.isConst && f.computeConstantValue() == object)) {
       return Revivable._(
         source: url.removeFragment(),
-        accessor: '${clazz.name}.${e.name}',
+        accessor: '${element.name}.${e.name}',
       );
     }
   }

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.0
+version: 1.2.1-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -195,13 +195,14 @@ void main() {
     });
   });
 
-  group('Reviable', () {
+  group('Revivable', () {
     late List<ConstantReader> constants;
 
     setUpAll(() async {
       final library = await resolveSource(
         r'''
         library test_lib;
+        import 'dart:io';
 
         @Int64Like.ZERO
         @Duration(seconds: 30)
@@ -216,6 +217,7 @@ void main() {
         @PublicWithPrivateConstructor._()
         @_privateField
         @Wrapper(_privateFunction)
+        @ProcessStartMode.normal
         class Example {}
 
         class Int64Like implements Int64LikeBase{
@@ -373,6 +375,14 @@ void main() {
       expect(function.isPrivate, isTrue);
       expect(function.source.fragment, isEmpty);
       expect(function.accessor, '_privateFunction');
+    });
+
+    test('should decode public static fields backed by private constructors',
+        () {
+      final staticFieldWithPrivateImpl = constants[13].revive();
+      expect(staticFieldWithPrivateImpl.accessor, 'ProcessStartMode.normal');
+      expect(staticFieldWithPrivateImpl.isPrivate, isFalse);
+      expect(staticFieldWithPrivateImpl.source.fragment, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/source_gen/issues/577

This should also be a faster heuristic; when looking for an object of type Foo, check Foo's static fields first. This was already done for enums; I see no reason to do it for all classes.