### PR TITLE
Use 'CompilationUnitElement.classes' instead of 'types'.

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2-dev
+
+- Stop using deprecated `package:analyzer` API to access classes.
+
 ## 1.2.1
 
 - Allow reviving constants which are static fields defined on the class which

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -64,8 +64,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
     return !result.isPrivate;
   }
 
-  // ignore: deprecated_member_use
-  for (final type in origin!.definingCompilationUnit.types) {
+  for (final type in origin!.definingCompilationUnit.classes) {
     for (final e in type.fields
         .where((f) => f.isConst && f.computeConstantValue() == object)) {
       final result = Revivable._(

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -159,8 +159,8 @@ class LibraryReader {
   }
 
   /// All of the elements representing classes in this library.
-  // ignore: deprecated_member_use
-  Iterable<ClassElement> get classes => element.units.expand((cu) => cu.types);
+  Iterable<ClassElement> get classes =>
+      element.units.expand((cu) => cu.classes);
 
   /// All of the elements representing enums in this library.
   Iterable<ClassElement> get enums => element.units.expand((cu) => cu.enums);

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.1
+version: 1.2.2-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
We would like to remove it.
[https://dart-review.googlesource.com/c/sdk/+/235290](https://www.google.com/url?sa=D&q=https%3A%2F%2Fdart-review.googlesource.com%2Fc%2Fsdk%2F%2B%2F235290)