### PR TITLE
Fix a misleading regex

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.3-dev
+
 ## 1.2.2
 
 * Enable the fix for single cascade statements when formatting Dart code.

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -87,7 +87,7 @@ class CombiningBuilder implements Builder {
       [
         '^', // start of string
         RegExp.escape(inputBaseName), // file name, without extension
-        '.', // `.` character
+        r'\.', // `.` character
         partIdRegExpLiteral, // A valid part ID
         RegExp.escape(_partFiles), // the ending part extension
         '\$', // end of string

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.2
+version: 1.2.3-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
Closes #599

This looks like a bug, but it can't currently surface as a problem
because the character at that location is already guaranteed to be
correct due to the glob pattern.

We cannot shorten the regex to check only the end of the file name
because we need to also disallow names which have extra `.` where there
should be a single part identifier. We could simplify the regex to just
check the right number of characters up to the `.` and count on the glob
for the earlier part, but I think it is more readable with the full
regex.