### PR TITLE
Mention extension conflicts in README

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.3-dev
+
 ## 1.2.2
 
 * Enable the fix for single cascade statements when formatting Dart code.

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -65,7 +65,9 @@ generated code to end up:
   `part` in the original source file, use `PartBuilder`. You should choose an
   extension unique to your package. Multiple `Generator`s may output to this
   file, but they will all come from your package and you will set up the entire
-  list when constructing the builder.
+  list when constructing the builder. Using the extension `.g.dart` may cause
+  conflicts with other projects that use `SharedPartBuilder` since outputs must
+  be unique.
 - If you want to write standalone Dart library which can be `import`ed use
   `LibraryBuilder`. Only a single `Generator` may be used as a `LibraryBuilder`.
 
@@ -90,7 +92,7 @@ builders:
     auto_apply: dependents
     build_to: cache
     # To copy the `.g.part` content into `.g.dart` in the source tree
-    applies_builders: ["source_gen|combining_builder"]
+    applies_builders: ["source_gen:combining_builder"]
 ```
 
 ### Configuring `combining_builder` `ignore_for_file`
@@ -107,7 +109,7 @@ _Example `build.yaml` configuration:_
 targets:
   $default:
     builders:
-      source_gen|combining_builder:
+      source_gen:combining_builder:
         options:
           ignore_for_file:
           - lint_alpha
@@ -138,7 +140,7 @@ targets:
   $default:
     builders:
       # A SharedPartBuilder which uses the combining builder
-      source_gen|combining_builder:
+      source_gen:combining_builder:
         options:
           build_extensions:
             '^lib/{{}}.dart': 'lib/generated/{{}}.g.dart'

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.2
+version: 1.2.3-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
See #598

Call out that the reason to avoid using the same extension as the
combining part builder is to avoid conflicts in packages which use both.

Update examples to use the `:` separator instead of the deprecated `|`
for builder keys.