### PR TITLE
Store Annotated Elements in GeneratorForAnnotation

### DIFF
--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -41,15 +41,17 @@ import 'type_checker.dart';
 /// [T] and use the [Element] to iterate over fields. The [TypeChecker] utility
 /// may be helpful to check which elements have a given annotation.
 abstract class GeneratorForAnnotation<T> extends Generator {
-  const GeneratorForAnnotation();
+  GeneratorForAnnotation();
+  Iterable<AnnotatedElement>? annotatedElements;
 
   TypeChecker get typeChecker => TypeChecker.fromRuntime(T);
 
   @override
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {
     final values = <String>{};
+    annotatedElements = library.annotatedWith(typeChecker);
 
-    for (var annotatedElement in library.annotatedWith(typeChecker)) {
+    for (var annotatedElement in annotatedElements!) {
       final generatedValue = generateForAnnotatedElement(
         annotatedElement.element,
         annotatedElement.annotation,

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -142,7 +142,7 @@ class _StubGenerator<T> extends GeneratorForAnnotation<T> {
   final String _name;
   final Object? Function(Element) _behavior;
 
-  const _StubGenerator(this._name, this._behavior);
+  _StubGenerator(this._name, this._behavior);
 
   @override
   Object? generateForAnnotatedElement(


### PR DESCRIPTION
Store annotated elements inside GeneratorForAnnotation so you can compare elements to see if its the last element present 

Example would be generating an Enum based off all annotated elements of type T i.e returning the completed Enum string on the last element

``` dart
class EnumGenerator extends GeneratorForAnnotation<Example> {
      @override
       Future<String> generateForAnnotatedElement(
          Element element,
          ConstantReader annotation,
          BuildStep buildStep) async {
            if (annotatedElements!.last.element == element) {
               // do something for the last element 
             } 
      }
    }
```