### PR TITLE
Avoid deprecated analyzer APIs

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 1.2.3
+## 1.2.3-dev
 
-* Require `analyzer: '>=4.3.0 <5.0.0'`
+* Require `analyzer: ^4.4.0`
 * Require `sdk: '>=2.17.0 <3.0.0'`
 
 ## 1.2.2

--- a/source_gen/lib/src/constants/reader.dart
+++ b/source_gen/lib/src/constants/reader.dart
@@ -271,7 +271,7 @@ class _DartObjectConstant extends ConstantReader {
   ConstantReader read(String field) {
     final reader = peek(field);
     if (reader == null) {
-      assertHasField(objectValue.type?.element as ClassElement, field);
+      assertHasField(objectValue.type?.element2 as ClassElement, field);
       return const _NullConstant();
     }
     return reader;

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -24,7 +24,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   Element? element = objectType!.alias?.element;
   if (element == null) {
     if (objectType is InterfaceType) {
-      element = objectType.element;
+      element = objectType.element2;
     } else {
       element = object.toFunctionValue();
     }
@@ -40,7 +40,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   if (element is MethodElement && element.isStatic) {
     return Revivable._(
       source: url.removeFragment(),
-      accessor: '${element.enclosingElement2.name}.${element.name}',
+      accessor: '${element.enclosingElement3.name}.${element.name}',
     );
   }
 
@@ -78,7 +78,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   }
   final i = (object as DartObjectImpl).getInvocation();
   if (i != null) {
-    url = Uri.parse(urlOfElement(i.constructor.enclosingElement2));
+    url = Uri.parse(urlOfElement(i.constructor.enclosingElement3));
     final result = Revivable._(
       source: url,
       accessor: i.constructor.name,

--- a/source_gen/lib/src/constants/utils.dart
+++ b/source_gen/lib/src/constants/utils.dart
@@ -7,18 +7,18 @@ import 'package:analyzer/dart/element/element.dart';
 
 /// Throws a [FormatException] if [root] does not have a given field [name].
 ///
-/// Super types [ClassElement.supertype] are also checked before throwing.
-void assertHasField(ClassElement root, String name) {
-  ClassElement? element = root;
+/// Super types [InterfaceElement.supertype] are also checked before throwing.
+void assertHasField(InterfaceElement root, String name) {
+  InterfaceElement? element = root;
   while (element != null) {
     final field = element.getField(name);
     if (field != null) {
       return;
     }
-    element = element.supertype?.element;
+    element = element.supertype?.element2;
   }
   final allFields = root.fields.toSet()
-    ..addAll(root.allSupertypes.expand((t) => t.element.fields));
+    ..addAll(root.allSupertypes.expand((t) => t.element2.fields));
   throw FormatException(
     'Class ${root.name} does not have field "$name".',
     'Fields: \n  - ${allFields.map((e) => e.name).join('\n  - ')}',

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -26,8 +26,8 @@ class LibraryReader {
 
   /// Returns a top-level [ClassElement] publicly visible in by [name].
   ///
-  /// Unlike [LibraryElement.getType], this also correctly traverses identifiers
-  /// that are accessible via one or more `export` directives.
+  /// Unlike [LibraryElement.getClass], this also correctly traverses
+  /// identifiers that are accessible via one or more `export` directives.
   ClassElement? findType(String name) {
     final type = element.exportNamespace.get(name);
     return type is ClassElement ? type : null;
@@ -163,5 +163,5 @@ class LibraryReader {
       element.units.expand((cu) => cu.classes);
 
   /// All of the elements representing enums in this library.
-  Iterable<ClassElement> get enums => element.units.expand((cu) => cu.enums);
+  Iterable<EnumElement> get enums => element.units.expand((cu) => cu.enums2);
 }

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -168,13 +168,13 @@ abstract class TypeChecker {
 
   /// Returns `true` if [staticType] can be assigned to this type.
   bool isAssignableFromType(DartType staticType) =>
-      isAssignableFrom(staticType.element!);
+      isAssignableFrom(staticType.element2!);
 
   /// Returns `true` if representing the exact same class as [element].
   bool isExactly(Element element);
 
   /// Returns `true` if representing the exact same type as [staticType].
-  bool isExactlyType(DartType staticType) => isExactly(staticType.element!);
+  bool isExactlyType(DartType staticType) => isExactly(staticType.element2!);
 
   /// Returns `true` if representing a super class of [element].
   ///
@@ -200,7 +200,7 @@ abstract class TypeChecker {
   ///
   /// This only takes into account the *extends* hierarchy. If you wish
   /// to check mixins and interfaces, use [isAssignableFromType].
-  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element!);
+  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element2!);
 }
 
 // Checks a static type against another static type;
@@ -211,10 +211,10 @@ class _LibraryTypeChecker extends TypeChecker {
 
   @override
   bool isExactly(Element element) =>
-      element is ClassElement && element == _type.element;
+      element is ClassElement && element == _type.element2;
 
   @override
-  String toString() => urlOfElement(_type.element!);
+  String toString() => urlOfElement(_type.element2!);
 }
 
 // Checks a runtime type against a static type.

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -30,10 +30,10 @@ String typeNameOf(DartType type) {
     return 'dynamic';
   }
   if (type is InterfaceType) {
-    return type.element.name;
+    return type.element2.name;
   }
   if (type is TypeParameterType) {
-    return type.element.name;
+    return type.element2.name;
   }
   throw UnimplementedError('(${type.runtimeType}) $type');
 }

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: ^4.4.0
+  analyzer: ^4.6.0
   async: ^2.5.0
   build: ^2.1.0
   dart_style: ^2.0.0

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.3
+version: 1.2.3-dev
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=4.3.0 <5.0.0'
+  analyzer: ^4.4.0
   async: ^2.5.0
   build: ^2.1.0
   dart_style: ^2.0.0

--- a/source_gen/test/constants/utils_test.dart
+++ b/source_gen/test/constants/utils_test.dart
@@ -34,17 +34,17 @@ void main() {
     });
 
     test('should not throw when a class contains a field', () {
-      final $A = testLib.getType('A')!;
+      final $A = testLib.getClass('A')!;
       expect(() => assertHasField($A, 'a'), returnsNormally);
     });
 
     test('should not throw when a super class contains a field', () {
-      final $B = testLib.getType('B')!;
+      final $B = testLib.getClass('B')!;
       expect(() => assertHasField($B, 'a'), returnsNormally);
     });
 
     test('should throw when a class does not contain a field', () {
-      final $C = testLib.getType('C')!;
+      final $C = testLib.getClass('C')!;
       expect(() => assertHasField($C, 'a'), throwsFormatException);
     });
   });
@@ -83,7 +83,7 @@ void main() {
         (resolver) async => (await resolver.findLibraryByName('test_lib'))!,
       );
       objects = testLib
-          .getType('Example')!
+          .getClass('Example')!
           .metadata
           .map((e) => e.computeConstantValue()!)
           .toList();

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -62,7 +62,7 @@ void main() {
         (resolver) async => (await resolver.findLibraryByName('test_lib'))!,
       );
       constants = library
-          .getType('Example')!
+          .getClass('Example')!
           .metadata
           .map((e) => ConstantReader(e.computeConstantValue()!))
           .toList();
@@ -156,7 +156,7 @@ void main() {
 
     test('should read a Type', () {
       expect(constants[11].isType, isTrue);
-      expect(constants[11].typeValue.element!.name, 'DateTime');
+      expect(constants[11].typeValue.element2!.name, 'DateTime');
       expect(constants[11].isLiteral, isFalse);
       expect(() => constants[11].literalValue, throwsFormatException);
     });
@@ -301,7 +301,7 @@ void main() {
         (resolver) async => (await resolver.findLibraryByName('test_lib'))!,
       );
       constants = library
-          .getType('Example')!
+          .getClass('Example')!
           .metadata
           .map((e) => ConstantReader(e.computeConstantValue()))
           .toList();

--- a/source_gen/test/external_only_type_checker_test.dart
+++ b/source_gen/test/external_only_type_checker_test.dart
@@ -51,7 +51,7 @@ void main() {
         expect(
           checkNonPublic().isExactlyType(staticNonPublic),
           isTrue,
-          reason: '${checkNonPublic()} != ${staticNonPublic.element.name}',
+          reason: '${checkNonPublic()} != ${staticNonPublic.element2.name}',
         );
       });
 
@@ -60,7 +60,7 @@ void main() {
           checkNonPublic().isAssignableFromType(staticNonPublic),
           isTrue,
           reason: '${checkNonPublic()} is not assignable from '
-              '${staticNonPublic.element.name}',
+              '${staticNonPublic.element2.name}',
         );
       });
     });

--- a/source_gen/test/span_for_element_test.dart
+++ b/source_gen/test/span_for_element_test.dart
@@ -35,7 +35,7 @@ abstract class Example implements List {
 
   test('should highlight the use of "class Example"', () async {
     expect(
-      spanForElement(library.getType('Example')!).message('Here it is'),
+      spanForElement(library.getClass('Example')!).message('Here it is'),
       r"""
 line 3, column 16 of package:test_lib/test_lib.dart: Here it is
   ,
@@ -47,7 +47,7 @@ line 3, column 16 of package:test_lib/test_lib.dart: Here it is
 
   test('should correctly highlight getter', () async {
     expect(
-      spanForElement(library.getType('Example')!.getField('getter')!)
+      spanForElement(library.getClass('Example')!.getField('getter')!)
           .message('Here it is'),
       r"""
 line 4, column 15 of package:test_lib/test_lib.dart: Here it is
@@ -60,7 +60,7 @@ line 4, column 15 of package:test_lib/test_lib.dart: Here it is
 
   test('should correctly highlight setter', () async {
     expect(
-      spanForElement(library.getType('Example')!.getField('setter')!)
+      spanForElement(library.getClass('Example')!.getField('setter')!)
           .message('Here it is'),
       r"""
 line 5, column 7 of package:test_lib/test_lib.dart: Here it is
@@ -73,7 +73,7 @@ line 5, column 7 of package:test_lib/test_lib.dart: Here it is
 
   test('should correctly highlight field', () async {
     expect(
-      spanForElement(library.getType('Example')!.getField('field')!)
+      spanForElement(library.getClass('Example')!.getField('field')!)
           .message('Here it is'),
       r"""
 line 6, column 7 of package:test_lib/test_lib.dart: Here it is
@@ -86,7 +86,7 @@ line 6, column 7 of package:test_lib/test_lib.dart: Here it is
 
   test('highlight getter with getter/setter property', () async {
     expect(
-      spanForElement(library.getType('Example')!.getField('fieldProp')!)
+      spanForElement(library.getClass('Example')!.getField('fieldProp')!)
           .message('Here it is'),
       r"""
 line 7, column 11 of package:test_lib/test_lib.dart: Here it is

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -50,16 +50,16 @@ void main() {
       inputId: AssetId('source_gen', 'test/example.dart'),
     );
 
-    final staticIterable = core.getType('Iterable')!.instantiate(
+    final staticIterable = core.getClass('Iterable')!.instantiate(
       typeArguments: [core.typeProvider.dynamicType],
       nullabilitySuffix: NullabilitySuffix.none,
     );
     staticIterableChecker = TypeChecker.fromStatic(staticIterable);
-    staticUri = core.getType('Uri')!.instantiate(
+    staticUri = core.getClass('Uri')!.instantiate(
       typeArguments: [],
       nullabilitySuffix: NullabilitySuffix.none,
     );
-    staticMap = core.getType('Map')!.instantiate(
+    staticMap = core.getClass('Map')!.instantiate(
       typeArguments: [
         core.typeProvider.dynamicType,
         core.typeProvider.dynamicType
@@ -68,7 +68,7 @@ void main() {
     );
     staticMapChecker = TypeChecker.fromStatic(staticMap);
 
-    staticHashMap = collection.getType('HashMap')!.instantiate(
+    staticHashMap = collection.getClass('HashMap')!.instantiate(
       typeArguments: [
         core.typeProvider.dynamicType,
         core.typeProvider.dynamicType
@@ -77,7 +77,7 @@ void main() {
     );
     staticHashMapChecker = TypeChecker.fromStatic(staticHashMap);
     staticUnmodifiableListView =
-        collection.getType('UnmodifiableListView')!.instantiate(
+        collection.getClass('UnmodifiableListView')!.instantiate(
       typeArguments: [core.typeProvider.dynamicType],
       nullabilitySuffix: NullabilitySuffix.none,
     );
@@ -119,7 +119,7 @@ void main() {
         expect(
           checkMap().isExactlyType(staticMap),
           isTrue,
-          reason: '${checkMap()} != ${staticMap.element.name}',
+          reason: '${checkMap()} != ${staticMap.element2.name}',
         );
       });
 
@@ -177,7 +177,7 @@ void main() {
         expect(
           checkGenerator().isExactlyType(staticGenerator),
           isTrue,
-          reason: '${checkGenerator()} != ${staticGenerator.element.name}',
+          reason: '${checkGenerator()} != ${staticGenerator.element2.name}',
         );
       });
 
@@ -186,7 +186,7 @@ void main() {
           checkGenerator().isSuperTypeOf(staticGenerator),
           isFalse,
           reason: '${checkGenerator()} is super of '
-              '${staticGenerator.element.name}',
+              '${staticGenerator.element2.name}',
         );
       });
 
@@ -195,7 +195,7 @@ void main() {
           checkGenerator().isSuperTypeOf(staticGeneratorForAnnotation),
           isTrue,
           reason: '${checkGenerator()} is not super of '
-              '${staticGeneratorForAnnotation.element.name}',
+              '${staticGeneratorForAnnotation.element2.name}',
         );
       });
 
@@ -204,7 +204,7 @@ void main() {
           checkGenerator().isAssignableFromType(staticGeneratorForAnnotation),
           isTrue,
           reason: '${checkGenerator()} is not assignable from '
-              '${staticGeneratorForAnnotation.element.name}',
+              '${staticGeneratorForAnnotation.element2.name}',
         );
       });
     });
@@ -255,7 +255,7 @@ void main() {
     ''',
       (resolver) async => (await resolver.findLibraryByName('_test'))!,
     );
-    final classX = library.getType('X')!;
+    final classX = library.getClass('X')!;
     const $deprecated = TypeChecker.fromRuntime(Deprecated);
 
     expect(
@@ -327,60 +327,60 @@ void main() {
       );
 
       $A = TypeChecker.fromStatic(
-        library.getType('A')!.instantiate(
+        library.getClass('A')!.instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         ),
       );
       $B = TypeChecker.fromStatic(
-        library.getType('B')!.instantiate(
+        library.getClass('B')!.instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         ),
       );
       $C = TypeChecker.fromStatic(
-        library.getType('C')!.instantiate(
+        library.getClass('C')!.instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         ),
       );
-      $ExampleOfA = library.getType('ExampleOfA')!;
-      $ExampleOfMultiA = library.getType('ExampleOfMultiA')!;
-      $ExampleOfAPlusB = library.getType('ExampleOfAPlusB')!;
-      $ExampleOfBPlusC = library.getType('ExampleOfBPlusC')!;
+      $ExampleOfA = library.getClass('ExampleOfA')!;
+      $ExampleOfMultiA = library.getClass('ExampleOfMultiA')!;
+      $ExampleOfAPlusB = library.getClass('ExampleOfAPlusB')!;
+      $ExampleOfBPlusC = library.getClass('ExampleOfBPlusC')!;
     });
 
     test('of a single @A', () {
       expect($A.hasAnnotationOf($ExampleOfA), isTrue);
       final aAnnotation = $A.firstAnnotationOf($ExampleOfA)!;
-      expect(aAnnotation.type!.element!.name, 'A');
+      expect(aAnnotation.type!.element2!.name, 'A');
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a multiple @A', () {
       final aAnnotations = $A.annotationsOf($ExampleOfMultiA);
-      expect(aAnnotations.map((a) => a.type!.element!.name), ['A', 'A']);
+      expect(aAnnotations.map((a) => a.type!.element2!.name), ['A', 'A']);
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a single @A + single @B', () {
       final aAnnotations = $A.annotationsOf($ExampleOfAPlusB);
-      expect(aAnnotations.map((a) => a.type!.element!.name), ['A']);
+      expect(aAnnotations.map((a) => a.type!.element2!.name), ['A']);
       final bAnnotations = $B.annotationsOf($ExampleOfAPlusB);
-      expect(bAnnotations.map((a) => a.type!.element!.name), ['B']);
+      expect(bAnnotations.map((a) => a.type!.element2!.name), ['B']);
       expect($C.annotationsOf($ExampleOfAPlusB), isEmpty);
     });
 
     test('of a single @B + single @C', () {
       final cAnnotations = $C.annotationsOf($ExampleOfBPlusC);
-      expect(cAnnotations.map((a) => a.type!.element!.name), ['C']);
+      expect(cAnnotations.map((a) => a.type!.element2!.name), ['C']);
       final bAnnotations = $B.annotationsOf($ExampleOfBPlusC);
-      expect(bAnnotations.map((a) => a.type!.element!.name), ['B', 'C']);
+      expect(bAnnotations.map((a) => a.type!.element2!.name), ['B', 'C']);
       expect($B.hasAnnotationOfExact($ExampleOfBPlusC), isTrue);
       final bExact = $B.annotationsOfExact($ExampleOfBPlusC);
-      expect(bExact.map((a) => a.type!.element!.name), ['B']);
+      expect(bExact.map((a) => a.type!.element2!.name), ['B']);
     });
   });
 
@@ -408,12 +408,12 @@ void main() {
         (resolver) async => (await resolver.findLibraryByName('_test'))!,
       );
       $A = TypeChecker.fromStatic(
-        library.getType('A')!.instantiate(
+        library.getClass('A')!.instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         ),
       );
-      $ExampleOfA = library.getType('ExampleOfA')!;
+      $ExampleOfA = library.getClass('ExampleOfA')!;
       $annotatedParameter = library.topLevelElements
           .whereType<FunctionElement>()
           .firstWhere((f) => f.name == 'annotatedParameter')
@@ -461,28 +461,28 @@ void main() {
         $A
             .firstAnnotationOf($ExampleOfA, throwOnUnresolved: false)!
             .type!
-            .element!
+            .element2!
             .name,
         'A',
       );
       expect(
         $A
             .annotationsOf($ExampleOfA, throwOnUnresolved: false)
-            .map((a) => a.type!.element!.name),
+            .map((a) => a.type!.element2!.name),
         ['A'],
       );
       expect(
         $A
             .firstAnnotationOfExact($ExampleOfA, throwOnUnresolved: false)!
             .type!
-            .element!
+            .element2!
             .name,
         'A',
       );
       expect(
         $A
             .annotationsOfExact($ExampleOfA, throwOnUnresolved: false)
-            .map((a) => a.type!.element!.name),
+            .map((a) => a.type!.element2!.name),
         ['A'],
       );
     });

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -28,7 +28,7 @@ void main() {
       source,
       (resolver) => resolver
           .findLibraryByName('example')
-          .then((e) => e!.getType('Example')!),
+          .then((e) => e!.getClass('Example')!),
     );
   });
 


### PR DESCRIPTION
Bump min analyzer to `^4.4.0` which introduces some of the new APIs
used.

Switch from `ClassElement` to `InterfaceElement` in a utility method to
match the `element2` return type.