### PR TITLE
Prepare for separation of ClassElement, EnumElement and MixinElement.

### DIFF
--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -44,7 +44,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
     );
   }
 
-  if (element is ClassElement) {
+  if (element is InterfaceElement) {
     for (final e in element.fields.where(
       (f) => f.isPublic && f.isConst && f.computeConstantValue() == object,
     )) {


### PR DESCRIPTION
All three implement `InterfaceElement`, but in the breaking change for `analyzer` we will stop implementing `ClassElement` in `EnumElement` and `MixinElement`. This is a minimal change necessary to make google3 green, the might be need for more changes that are not exercised there.