### PR TITLE
Fix another type issue, prepare for v1.2.5

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.5
+
+* Fix another issue with overly specific types.
+
 ## 1.2.4
 
 * Fix overly-specific cast.

--- a/source_gen/lib/src/constants/utils.dart
+++ b/source_gen/lib/src/constants/utils.dart
@@ -17,8 +17,11 @@ void assertHasField(InterfaceElement root, String name) {
     }
     element = element.supertype?.element2;
   }
-  final allFields = root.fields.toSet()
-    ..addAll(root.allSupertypes.expand((t) => t.element2.fields));
+  final allFields = {
+    ...root.fields,
+    for (var t in root.allSupertypes) ...t.element2.fields,
+  };
+
   throw FormatException(
     'Class ${root.name} does not have field "$name".',
     'Fields: \n  - ${allFields.map((e) => e.name).join('\n  - ')}',

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.4
+version: 1.2.5
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen


### PR DESCRIPTION
`root.fields` has a runtime type of `Iterable<FieldElementImpl>` which
is not compatible with the value used in the `addAll` call.

Using collection literal syntax to fix the issue

Runtime error:
`type 'ExpandIterable<InterfaceType, FieldElement>' is not a subtype of type 'Iterable<FieldElementImpl>' of 'other'`
