### PR TITLE
Add preamble to CombiningBuilder

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.6
+
+* Add support for a `preamble` option to `combining_builder`.
+
 ## 1.2.5
 
 * Fix another issue with overly specific types.

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -95,7 +95,9 @@ builders:
     applies_builders: ["source_gen:combining_builder"]
 ```
 
-### Configuring `combining_builder` `ignore_for_file`
+### Configuring `combining_builder` 
+
+#### `ignore_for_file`
 
 Sometimes generated code does not support all of the
 [lints](https://dart-lang.github.io/linter/) specified in the target package.
@@ -114,6 +116,26 @@ targets:
           ignore_for_file:
           - lint_alpha
           - lint_beta
+```
+
+#### `preamble`
+
+When using a `Builder` based on `package:source_gen` which applies
+`combining_builder`, set the `preamble` option to a string you
+wish to be prepended to all generated libraries.
+
+_Example `build.yaml` configuration:_
+
+```yaml
+targets:
+  $default:
+    builders:
+      source_gen:combining_builder:
+        options:
+          preamble: |
+                // Foo
+                
+                // Bar
 ```
 
 If you provide a builder that uses `SharedPartBuilder` and `combining_builder`,

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -138,8 +138,11 @@ targets:
                 // Bar
 ```
 
+Hint: When both `ignore_for_file` and `preamble` are used the generated libraries will contain the lints of
+`ignore_for_file` on top of the `preamble`.
+
 If you provide a builder that uses `SharedPartBuilder` and `combining_builder`,
-you should document this feature for your users.
+you should document these features for your users.
 
 ### Generating files in different directories
 

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -32,12 +32,16 @@ Builder combiningBuilder([BuilderOptions options = BuilderOptions.empty]) {
   final ignoreForFile = Set<String>.from(
     optionsMap.remove('ignore_for_file') as List? ?? <String>[],
   );
+  final preamble = List<String>.from(
+    optionsMap.remove('preamble') as List? ?? <String>[],
+  );
   final buildExtensions =
       validatedBuildExtensionsFrom(optionsMap, _defaultExtensions);
 
   final builder = CombiningBuilder(
     includePartName: includePartName,
     ignoreForFile: ignoreForFile,
+    preamble: preamble,
     buildExtensions: buildExtensions,
   );
 
@@ -58,6 +62,8 @@ class CombiningBuilder implements Builder {
 
   final Set<String> _ignoreForFile;
 
+  final List<String> _preamble;
+
   @override
   final Map<String, List<String>> buildExtensions;
 
@@ -69,9 +75,11 @@ class CombiningBuilder implements Builder {
   const CombiningBuilder({
     bool? includePartName,
     Set<String>? ignoreForFile,
+    List<String>? preamble,
     this.buildExtensions = _defaultExtensions,
   })  : _includePartName = includePartName ?? false,
-        _ignoreForFile = ignoreForFile ?? const <String>{};
+        _ignoreForFile = ignoreForFile ?? const <String>{},
+        _preamble = preamble ?? const <String>[];
 
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -131,9 +139,12 @@ class CombiningBuilder implements Builder {
     final ignoreForFile = _ignoreForFile.isEmpty
         ? ''
         : '\n// ignore_for_file: ${_ignoreForFile.join(', ')}\n';
+
+    final preamble = _preamble.isEmpty ? '' : '\n${_preamble.join('\n')}\n';
+
     final output = '''
 $defaultFileHeader
-${languageOverrideForLibrary(inputLibrary)}$ignoreForFile
+${languageOverrideForLibrary(inputLibrary)}$ignoreForFile$preamble
 part of $partOf;
 
 $assets

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -32,9 +32,7 @@ Builder combiningBuilder([BuilderOptions options = BuilderOptions.empty]) {
   final ignoreForFile = Set<String>.from(
     optionsMap.remove('ignore_for_file') as List? ?? <String>[],
   );
-  final preamble = List<String>.from(
-    optionsMap.remove('preamble') as List? ?? <String>[],
-  );
+  final preamble = optionsMap.remove('preamble') as String? ?? '';
   final buildExtensions =
       validatedBuildExtensionsFrom(optionsMap, _defaultExtensions);
 
@@ -62,7 +60,7 @@ class CombiningBuilder implements Builder {
 
   final Set<String> _ignoreForFile;
 
-  final List<String> _preamble;
+  final String _preamble;
 
   @override
   final Map<String, List<String>> buildExtensions;
@@ -75,11 +73,11 @@ class CombiningBuilder implements Builder {
   const CombiningBuilder({
     bool? includePartName,
     Set<String>? ignoreForFile,
-    List<String>? preamble,
+    String? preamble,
     this.buildExtensions = _defaultExtensions,
   })  : _includePartName = includePartName ?? false,
         _ignoreForFile = ignoreForFile ?? const <String>{},
-        _preamble = preamble ?? const <String>[];
+        _preamble = preamble ?? '';
 
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -140,7 +138,7 @@ class CombiningBuilder implements Builder {
         ? ''
         : '\n// ignore_for_file: ${_ignoreForFile.join(', ')}\n';
 
-    final preamble = _preamble.isEmpty ? '' : '\n${_preamble.join('\n')}\n';
+    final preamble = _preamble.isEmpty ? '' : '\n$_preamble\n';
 
     final output = '''
 $defaultFileHeader

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.5
+version: 1.2.6
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -678,6 +678,46 @@ foo generated content
       );
     });
 
+    test('includes preamble if enabled', () async {
+      await testBuilder(
+        const CombiningBuilder(
+          preamble: [
+            '// coverage:ignore-file',
+            '',
+            '// ignore_for_file: type=lint',
+            '',
+            '// Foo bar',
+          ],
+        ),
+        {
+          '$_pkgName|lib/a.dart': 'library a; part "a.g.dart";',
+          '$_pkgName|lib/a.foo.g.part': '\n\nfoo generated content\n',
+          '$_pkgName|lib/a.only_whitespace.g.part': '\n\n\t  \n \n',
+          '$_pkgName|lib/a.bar.g.part': '\nbar generated content',
+        },
+        generateFor: {'$_pkgName|lib/a.dart'},
+        outputs: {
+          '$_pkgName|lib/a.g.dart': decodedMatches(
+            endsWith(
+              r'''
+// coverage:ignore-file
+
+// ignore_for_file: type=lint
+
+// Foo bar
+
+part of a;
+
+bar generated content
+
+foo generated content
+''',
+            ),
+          ),
+        },
+      );
+    });
+
     test('warns about missing part statement', () async {
       final logs = <String>[];
       await testBuilder(

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -697,9 +697,9 @@ foo generated content
           '$_pkgName|lib/a.g.dart': decodedMatches(
             endsWith(
               r'''
-foo
+// foo
 
-bar
+// bar
 
 part of a;
 

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -681,13 +681,10 @@ foo generated content
     test('includes preamble if enabled', () async {
       await testBuilder(
         const CombiningBuilder(
-          preamble: [
-            '// coverage:ignore-file',
-            '',
-            '// ignore_for_file: type=lint',
-            '',
-            '// Foo bar',
-          ],
+          preamble: '''
+foo
+
+bar''',
         ),
         {
           '$_pkgName|lib/a.dart': 'library a; part "a.g.dart";',
@@ -700,11 +697,9 @@ foo generated content
           '$_pkgName|lib/a.g.dart': decodedMatches(
             endsWith(
               r'''
-// coverage:ignore-file
+foo
 
-// ignore_for_file: type=lint
-
-// Foo bar
+bar
 
 part of a;
 

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -682,9 +682,9 @@ foo generated content
       await testBuilder(
         const CombiningBuilder(
           preamble: '''
-foo
+// foo
 
-bar''',
+// bar''',
         ),
         {
           '$_pkgName|lib/a.dart': 'library a; part "a.g.dart";',


### PR DESCRIPTION
Adds a `preamble` to `CombiningBuilder` as discussed in (#624).

TODO:
Wheter remove or deprecate `ignoreForFile`
Doc update 
