### PR TITLE
Update calls to deprecated analyzer APIs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.3.0
+# Created with package:mono_repo v6.4.2
 name: Dart CI
 on:
   push:
@@ -21,56 +21,60 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.3.0
+        run: dart pub global activate mono_repo 6.4.2
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_format; linux; Dart 2.17.6; PKG: source_gen; `dart analyze`"
+    name: "analyze_format; linux; Dart 2.18.0; PKG: source_gen; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6;packages:source_gen;commands:analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:source_gen;commands:analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6;packages:source_gen
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:source_gen
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.6"
+          sdk: "2.18.0"
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: source_gen; dart analyze
+        run: dart analyze
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
-        run: dart analyze
   job_003:
     name: "analyze_format; linux; Dart dev; PKGS: _test_annotations, example, example_usage, source_gen; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_annotations-example-example_usage-source_gen;commands:format-analyze_0"
@@ -79,109 +83,115 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: _test_annotations_pub_upgrade
         name: _test_annotations; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: _test_annotations
-        run: dart pub upgrade
       - name: "_test_annotations; dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps._test_annotations_pub_upgrade.conclusion == 'success'"
-        working-directory: _test_annotations
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "_test_annotations; dart analyze --fatal-infos ."
         if: "always() && steps._test_annotations_pub_upgrade.conclusion == 'success'"
         working-directory: _test_annotations
+      - name: "_test_annotations; dart analyze --fatal-infos ."
         run: dart analyze --fatal-infos .
+        if: "always() && steps._test_annotations_pub_upgrade.conclusion == 'success'"
+        working-directory: _test_annotations
       - id: example_pub_upgrade
         name: example; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: example
-        run: dart pub upgrade
       - name: "example; dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
-        working-directory: example
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "example; dart analyze --fatal-infos ."
         if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
         working-directory: example
+      - name: "example; dart analyze --fatal-infos ."
         run: dart analyze --fatal-infos .
+        if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
+        working-directory: example
       - id: example_usage_pub_upgrade
         name: example_usage; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: example_usage
-        run: dart pub upgrade
       - name: "example_usage; dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.example_usage_pub_upgrade.conclusion == 'success'"
-        working-directory: example_usage
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "example_usage; dart analyze --fatal-infos ."
         if: "always() && steps.example_usage_pub_upgrade.conclusion == 'success'"
         working-directory: example_usage
+      - name: "example_usage; dart analyze --fatal-infos ."
         run: dart analyze --fatal-infos .
+        if: "always() && steps.example_usage_pub_upgrade.conclusion == 'success'"
+        working-directory: example_usage
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: "source_gen; dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
-        working-directory: source_gen
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "source_gen; dart analyze --fatal-infos ."
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
+      - name: "source_gen; dart analyze --fatal-infos ."
         run: dart analyze --fatal-infos .
+        if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
+        working-directory: source_gen
   job_004:
-    name: "analyze_format; windows; Dart 2.17.6; PKG: source_gen; `dart analyze`"
+    name: "analyze_format; windows; Dart 2.18.0; PKG: source_gen; `dart analyze`"
     runs-on: windows-latest
     steps:
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.6"
+          sdk: "2.18.0"
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: source_gen; dart analyze
+        run: dart analyze
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
-        run: dart analyze
   job_005:
     name: "analyze_format; windows; Dart dev; PKG: source_gen; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: windows-latest
     steps:
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: "source_gen; dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
-        working-directory: source_gen
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "source_gen; dart analyze --fatal-infos ."
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
+      - name: "source_gen; dart analyze --fatal-infos ."
         run: dart analyze --fatal-infos .
+        if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
+        working-directory: source_gen
   job_006:
     name: "unit_test; linux; Dart 2.17.6; PKG: example_usage; `dart test --run-skipped`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6;packages:example_usage;commands:test_0"
@@ -190,20 +200,22 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: "2.17.6"
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: example_usage_pub_upgrade
         name: example_usage; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: example_usage
-        run: dart pub upgrade
       - name: "example_usage; dart test --run-skipped"
+        run: dart test --run-skipped
         if: "always() && steps.example_usage_pub_upgrade.conclusion == 'success'"
         working-directory: example_usage
-        run: dart test --run-skipped
     needs:
       - job_001
       - job_002
@@ -211,33 +223,35 @@ jobs:
       - job_004
       - job_005
   job_007:
-    name: "unit_test; linux; Dart 2.17.6; PKG: source_gen; `dart test`"
+    name: "unit_test; linux; Dart 2.18.0; PKG: source_gen; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6;packages:source_gen;commands:test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:source_gen;commands:test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6;packages:source_gen
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:source_gen
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.6"
+          sdk: "2.18.0"
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: source_gen; dart test
+        run: dart test
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
-        run: dart test
     needs:
       - job_001
       - job_002
@@ -249,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:example_usage;commands:test_0"
@@ -258,20 +272,22 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: example_usage_pub_upgrade
         name: example_usage; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: example_usage
-        run: dart pub upgrade
       - name: "example_usage; dart test --run-skipped"
+        run: dart test --run-skipped
         if: "always() && steps.example_usage_pub_upgrade.conclusion == 'success'"
         working-directory: example_usage
-        run: dart test --run-skipped
     needs:
       - job_001
       - job_002
@@ -283,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:source_gen;commands:test_1"
@@ -292,20 +308,22 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: source_gen; dart test
+        run: dart test
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
-        run: dart test
     needs:
       - job_001
       - job_002
@@ -313,23 +331,25 @@ jobs:
       - job_004
       - job_005
   job_010:
-    name: "unit_test; windows; Dart 2.17.6; PKG: source_gen; `dart test`"
+    name: "unit_test; windows; Dart 2.18.0; PKG: source_gen; `dart test`"
     runs-on: windows-latest
     steps:
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.6"
+          sdk: "2.18.0"
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: source_gen; dart test
+        run: dart test
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
-        run: dart test
     needs:
       - job_001
       - job_002
@@ -340,20 +360,22 @@ jobs:
     name: "unit_test; windows; Dart dev; PKG: source_gen; `dart test`"
     runs-on: windows-latest
     steps:
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - id: source_gen_pub_upgrade
         name: source_gen; dart pub upgrade
+        run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: source_gen
-        run: dart pub upgrade
       - name: source_gen; dart test
+        run: dart test
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
-        run: dart test
     needs:
       - job_001
       - job_002

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -187,23 +187,23 @@ jobs:
         if: "always() && steps.source_gen_pub_upgrade.conclusion == 'success'"
         working-directory: source_gen
   job_006:
-    name: "unit_test; linux; Dart 2.17.6; PKG: example_usage; `dart test --run-skipped`"
+    name: "unit_test; linux; Dart 2.18.0; PKG: example_usage; `dart test --run-skipped`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6;packages:example_usage;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:example_usage;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6;packages:example_usage
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.6
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:example_usage
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.6"
+          sdk: "2.18.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/example_usage/mono_pkg.yaml
+++ b/example_usage/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/google/mono_repo.dart for details
 sdk:
-- 2.17.6
+- pubspec
 - dev
 
 stages:

--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -1,7 +1,7 @@
 name: source_gen_example_usage
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   source_gen_example:

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.7
+
+* Require Dart SDK version `2.18`.
+
 ## 1.2.6
 
 * Add support for a `preamble` option to `combining_builder`.

--- a/source_gen/lib/src/constants/reader.dart
+++ b/source_gen/lib/src/constants/reader.dart
@@ -271,7 +271,7 @@ class _DartObjectConstant extends ConstantReader {
   ConstantReader read(String field) {
     final reader = peek(field);
     if (reader == null) {
-      assertHasField(objectValue.type!.element2 as InterfaceElement, field);
+      assertHasField(objectValue.type!.element as InterfaceElement, field);
       return const _NullConstant();
     }
     return reader;

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -78,7 +78,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   }
   final i = (object as DartObjectImpl).getInvocation();
   if (i != null) {
-    url = Uri.parse(urlOfElement(i.constructor.enclosingElement3));
+    url = Uri.parse(urlOfElement(i.constructor.enclosingElement));
     final result = Revivable._(
       source: url,
       accessor: i.constructor.name,

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -24,7 +24,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   Element? element = objectType!.alias?.element;
   if (element == null) {
     if (objectType is InterfaceType) {
-      element = objectType.element2;
+      element = objectType.element;
     } else {
       element = object.toFunctionValue();
     }
@@ -40,7 +40,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
   if (element is MethodElement && element.isStatic) {
     return Revivable._(
       source: url.removeFragment(),
-      accessor: '${element.enclosingElement3.name}.${element.name}',
+      accessor: '${element.enclosingElement.name}.${element.name}',
     );
   }
 

--- a/source_gen/lib/src/constants/utils.dart
+++ b/source_gen/lib/src/constants/utils.dart
@@ -15,11 +15,11 @@ void assertHasField(InterfaceElement root, String name) {
     if (field != null) {
       return;
     }
-    element = element.supertype?.element2;
+    element = element.supertype?.element;
   }
   final allFields = {
     ...root.fields,
-    for (var t in root.allSupertypes) ...t.element2.fields,
+    for (var t in root.allSupertypes) ...t.element.fields,
   };
 
   throw FormatException(

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -163,5 +163,5 @@ class LibraryReader {
       element.units.expand((cu) => cu.classes);
 
   /// All of the elements representing enums in this library.
-  Iterable<EnumElement> get enums => element.units.expand((cu) => cu.enums2);
+  Iterable<EnumElement> get enums => element.units.expand((cu) => cu.enums);
 }

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -168,13 +168,13 @@ abstract class TypeChecker {
 
   /// Returns `true` if [staticType] can be assigned to this type.
   bool isAssignableFromType(DartType staticType) =>
-      isAssignableFrom(staticType.element2!);
+      isAssignableFrom(staticType.element!);
 
   /// Returns `true` if representing the exact same class as [element].
   bool isExactly(Element element);
 
   /// Returns `true` if representing the exact same type as [staticType].
-  bool isExactlyType(DartType staticType) => isExactly(staticType.element2!);
+  bool isExactlyType(DartType staticType) => isExactly(staticType.element!);
 
   /// Returns `true` if representing a super class of [element].
   ///
@@ -200,7 +200,7 @@ abstract class TypeChecker {
   ///
   /// This only takes into account the *extends* hierarchy. If you wish
   /// to check mixins and interfaces, use [isAssignableFromType].
-  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element2!);
+  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element!);
 }
 
 // Checks a static type against another static type;
@@ -211,10 +211,10 @@ class _LibraryTypeChecker extends TypeChecker {
 
   @override
   bool isExactly(Element element) =>
-      element is ClassElement && element == _type.element2;
+      element is ClassElement && element == _type.element;
 
   @override
-  String toString() => urlOfElement(_type.element2!);
+  String toString() => urlOfElement(_type.element!);
 }
 
 // Checks a runtime type against a static type.

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -30,10 +30,10 @@ String typeNameOf(DartType type) {
     return 'dynamic';
   }
   if (type is InterfaceType) {
-    return type.element2.name;
+    return type.element.name;
   }
   if (type is TypeParameterType) {
-    return type.element2.name;
+    return type.element.name;
   }
   throw UnimplementedError('(${type.runtimeType}) $type');
 }

--- a/source_gen/mono_pkg.yaml
+++ b/source_gen/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/google/mono_repo.dart for details
 sdk:
-- 2.17.6
+- pubspec
 - dev
 
 os:
@@ -15,7 +15,7 @@ stages:
     sdk: dev
   - group:
     - analyze
-    sdk: 2.17.6
+    sdk: pubspec
 - unit_test:
   - test
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=4.6.0 <6.0.0'
+  analyzer: ^5.2.0
   async: ^2.5.0
   build: ^2.1.0
   dart_style: ^2.0.0

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,11 +1,11 @@
 name: source_gen
-version: 1.2.6
+version: 1.2.7
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   analyzer: ^5.2.0

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -156,7 +156,7 @@ void main() {
 
     test('should read a Type', () {
       expect(constants[11].isType, isTrue);
-      expect(constants[11].typeValue.element2!.name, 'DateTime');
+      expect(constants[11].typeValue.element!.name, 'DateTime');
       expect(constants[11].isLiteral, isFalse);
       expect(() => constants[11].literalValue, throwsFormatException);
     });

--- a/source_gen/test/external_only_type_checker_test.dart
+++ b/source_gen/test/external_only_type_checker_test.dart
@@ -51,7 +51,7 @@ void main() {
         expect(
           checkNonPublic().isExactlyType(staticNonPublic),
           isTrue,
-          reason: '${checkNonPublic()} != ${staticNonPublic.element2.name}',
+          reason: '${checkNonPublic()} != ${staticNonPublic.element.name}',
         );
       });
 
@@ -60,7 +60,7 @@ void main() {
           checkNonPublic().isAssignableFromType(staticNonPublic),
           isTrue,
           reason: '${checkNonPublic()} is not assignable from '
-              '${staticNonPublic.element2.name}',
+              '${staticNonPublic.element.name}',
         );
       });
     });

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -119,7 +119,7 @@ void main() {
         expect(
           checkMap().isExactlyType(staticMap),
           isTrue,
-          reason: '${checkMap()} != ${staticMap.element2.name}',
+          reason: '${checkMap()} != ${staticMap.element.name}',
         );
       });
 
@@ -177,7 +177,7 @@ void main() {
         expect(
           checkGenerator().isExactlyType(staticGenerator),
           isTrue,
-          reason: '${checkGenerator()} != ${staticGenerator.element2.name}',
+          reason: '${checkGenerator()} != ${staticGenerator.element.name}',
         );
       });
 
@@ -186,7 +186,7 @@ void main() {
           checkGenerator().isSuperTypeOf(staticGenerator),
           isFalse,
           reason: '${checkGenerator()} is super of '
-              '${staticGenerator.element2.name}',
+              '${staticGenerator.element.name}',
         );
       });
 
@@ -195,7 +195,7 @@ void main() {
           checkGenerator().isSuperTypeOf(staticGeneratorForAnnotation),
           isTrue,
           reason: '${checkGenerator()} is not super of '
-              '${staticGeneratorForAnnotation.element2.name}',
+              '${staticGeneratorForAnnotation.element.name}',
         );
       });
 
@@ -204,7 +204,7 @@ void main() {
           checkGenerator().isAssignableFromType(staticGeneratorForAnnotation),
           isTrue,
           reason: '${checkGenerator()} is not assignable from '
-              '${staticGeneratorForAnnotation.element2.name}',
+              '${staticGeneratorForAnnotation.element.name}',
         );
       });
     });
@@ -353,34 +353,34 @@ void main() {
     test('of a single @A', () {
       expect($A.hasAnnotationOf($ExampleOfA), isTrue);
       final aAnnotation = $A.firstAnnotationOf($ExampleOfA)!;
-      expect(aAnnotation.type!.element2!.name, 'A');
+      expect(aAnnotation.type!.element!.name, 'A');
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a multiple @A', () {
       final aAnnotations = $A.annotationsOf($ExampleOfMultiA);
-      expect(aAnnotations.map((a) => a.type!.element2!.name), ['A', 'A']);
+      expect(aAnnotations.map((a) => a.type!.element!.name), ['A', 'A']);
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a single @A + single @B', () {
       final aAnnotations = $A.annotationsOf($ExampleOfAPlusB);
-      expect(aAnnotations.map((a) => a.type!.element2!.name), ['A']);
+      expect(aAnnotations.map((a) => a.type!.element!.name), ['A']);
       final bAnnotations = $B.annotationsOf($ExampleOfAPlusB);
-      expect(bAnnotations.map((a) => a.type!.element2!.name), ['B']);
+      expect(bAnnotations.map((a) => a.type!.element!.name), ['B']);
       expect($C.annotationsOf($ExampleOfAPlusB), isEmpty);
     });
 
     test('of a single @B + single @C', () {
       final cAnnotations = $C.annotationsOf($ExampleOfBPlusC);
-      expect(cAnnotations.map((a) => a.type!.element2!.name), ['C']);
+      expect(cAnnotations.map((a) => a.type!.element!.name), ['C']);
       final bAnnotations = $B.annotationsOf($ExampleOfBPlusC);
-      expect(bAnnotations.map((a) => a.type!.element2!.name), ['B', 'C']);
+      expect(bAnnotations.map((a) => a.type!.element!.name), ['B', 'C']);
       expect($B.hasAnnotationOfExact($ExampleOfBPlusC), isTrue);
       final bExact = $B.annotationsOfExact($ExampleOfBPlusC);
-      expect(bExact.map((a) => a.type!.element2!.name), ['B']);
+      expect(bExact.map((a) => a.type!.element!.name), ['B']);
     });
   });
 
@@ -461,28 +461,28 @@ void main() {
         $A
             .firstAnnotationOf($ExampleOfA, throwOnUnresolved: false)!
             .type!
-            .element2!
+            .element!
             .name,
         'A',
       );
       expect(
         $A
             .annotationsOf($ExampleOfA, throwOnUnresolved: false)
-            .map((a) => a.type!.element2!.name),
+            .map((a) => a.type!.element!.name),
         ['A'],
       );
       expect(
         $A
             .firstAnnotationOfExact($ExampleOfA, throwOnUnresolved: false)!
             .type!
-            .element2!
+            .element!
             .name,
         'A',
       );
       expect(
         $A
             .annotationsOfExact($ExampleOfA, throwOnUnresolved: false)
-            .map((a) => a.type!.element2!.name),
+            .map((a) => a.type!.element!.name),
         ['A'],
       );
     });

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.3.0
+# Created with package:mono_repo v6.4.2
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")


### PR DESCRIPTION
Bump the analyzer dependency to the latest which includes all the
replacement APIs.

Remove uses of deprecated APIs in favor of their replacements.
