### PR TITLE
Fix type-checking mixins and enum classes

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update the value of the pubspec `repository` field.
 * Require Dart SDK version `2.18`.
+* Fix type-checking mixin elements with `TypeChecker`.
 
 ## 1.2.6
 

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -164,7 +164,7 @@ abstract class TypeChecker {
   /// Returns `true` if the type of [element] can be assigned to this type.
   bool isAssignableFrom(Element element) =>
       isExactly(element) ||
-      (element is ClassElement && element.allSupertypes.any(isExactlyType));
+      (element is InterfaceElement && element.allSupertypes.any(isExactlyType));
 
   /// Returns `true` if [staticType] can be assigned to this type.
   bool isAssignableFromType(DartType staticType) =>
@@ -181,7 +181,7 @@ abstract class TypeChecker {
   /// This check only takes into account the *extends* hierarchy. If you wish
   /// to check mixins and interfaces, use [isAssignableFrom].
   bool isSuperOf(Element element) {
-    if (element is ClassElement) {
+    if (element is InterfaceElement) {
       var theSuper = element.supertype;
 
       do {
@@ -211,7 +211,7 @@ class _LibraryTypeChecker extends TypeChecker {
 
   @override
   bool isExactly(Element element) =>
-      element is ClassElement && element == _type.element;
+      element is InterfaceElement && element == _type.element;
 
   @override
   String toString() => urlOfElement(_type.element!);


### PR DESCRIPTION
In versions `5.x` of the `analyzer` packages, classes declared with the `mixin` or `enum` keyword are no longer represented as `ClassElement`s. They are reported as `MixinElement`s or `EnumElement`s, respectively.

Since `TypeChecker` and its implementation checks against `ClassElement` in a bunch of cases, the classes can no longer be compared. I think this is a bug in `source_gen` because

1. This used to work!
2. It's called a `TypeChecker`, not a `ClassChecker`. So anything contributing to the type hierarchy should be respected.

The fix is quite simple, one just needs to use the more-generic `InterfaceElement`.