### PR TITLE
Added coverage_ignore_file option to combining_builder

### DIFF
--- a/example_usage/build.yaml
+++ b/example_usage/build.yaml
@@ -18,6 +18,7 @@ targets:
       # may configure the builder to ignore specific lints for their project
       source_gen|combining_builder:
         options:
+          coverage_ignore_file: true
           ignore_for_file:
           - lint_a
           - lint_b

--- a/example_usage/lib/library_source.g.dart
+++ b/example_usage/lib/library_source.g.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: lint_a, lint_b

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.8
+
+* Add the `coverage_ignore_file` option to `combining_builder`, allowing output
+  files to be ignored from code coverage.
+
 ## 1.2.7
 
 * Update the value of the pubspec `repository` field.

--- a/source_gen/README.md
+++ b/source_gen/README.md
@@ -114,6 +114,22 @@ targets:
           - lint_beta
 ```
 
+#### `coverage_ignore_file`
+
+Sometimes when we run tests using `dart test --coverage` or `flutter test --coverage` we want to exclude the generated code from code coverage. When using a `Builder` based on `package:source_gen` which applies
+`combining_builder`, set the `coverage_ignore_file` option to a boolean, if the value is `true`,  all generated libraries will be excluded from the generated LCOV file.
+
+_Example `build.yaml` configuration:_
+
+```yaml
+targets:
+  $default:
+    builders:
+      source_gen:combining_builder:
+        options:
+          coverage_ignore_file: true
+```
+
 #### `preamble`
 
 When using a `Builder` based on `package:source_gen` which applies

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -35,12 +35,14 @@ Builder combiningBuilder([BuilderOptions options = BuilderOptions.empty]) {
   final preamble = optionsMap.remove('preamble') as String? ?? '';
   final buildExtensions =
       validatedBuildExtensionsFrom(optionsMap, _defaultExtensions);
+  final coverageIgnoreFile = optionsMap.remove('coverage_ignore_file') as bool?;
 
   final builder = CombiningBuilder(
     includePartName: includePartName,
     ignoreForFile: ignoreForFile,
     preamble: preamble,
     buildExtensions: buildExtensions,
+    coverageIgnoreFile: coverageIgnoreFile,
   );
 
   if (optionsMap.isNotEmpty) {
@@ -58,6 +60,8 @@ PostProcessBuilder partCleanup(BuilderOptions options) =>
 class CombiningBuilder implements Builder {
   final bool _includePartName;
 
+  final bool _coverageIgnoreFile;
+
   final Set<String> _ignoreForFile;
 
   final String _preamble;
@@ -72,10 +76,12 @@ class CombiningBuilder implements Builder {
   /// debugging build issues.
   const CombiningBuilder({
     bool? includePartName,
+    bool? coverageIgnoreFile,
     Set<String>? ignoreForFile,
     String? preamble,
     this.buildExtensions = _defaultExtensions,
   })  : _includePartName = includePartName ?? false,
+        _coverageIgnoreFile = coverageIgnoreFile ?? false,
         _ignoreForFile = ignoreForFile ?? const <String>{},
         _preamble = preamble ?? '';
 
@@ -140,7 +146,9 @@ class CombiningBuilder implements Builder {
 
     final preamble = _preamble.isEmpty ? '' : '\n$_preamble\n';
 
-    final output = '''
+    var output = _coverageIgnoreFile ? '// coverage:ignore-file\n' : '';
+
+    output += '''
 $defaultFileHeader
 ${languageOverrideForLibrary(inputLibrary)}$ignoreForFile$preamble
 part of $partOf;

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.7
+version: 1.2.8
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -713,6 +713,37 @@ foo generated content
       );
     });
 
+    test('includes coverage ignore file if enabled', () async {
+      await testBuilder(
+        const CombiningBuilder(
+          coverageIgnoreFile: true,
+        ),
+        {
+          '$_pkgName|lib/a.dart': 'library a; part "a.g.dart";',
+          '$_pkgName|lib/a.foo.g.part': '\n\nfoo generated content\n',
+          '$_pkgName|lib/a.only_whitespace.g.part': '\n\n\t  \n \n',
+          '$_pkgName|lib/a.bar.g.part': '\nbar generated content',
+        },
+        generateFor: {'$_pkgName|lib/a.dart'},
+        outputs: {
+          '$_pkgName|lib/a.g.dart': decodedMatches(
+            endsWith(
+              r'''
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of a;
+
+bar generated content
+
+foo generated content
+''',
+            ),
+          ),
+        },
+      );
+    });
+
     test('warns about missing part statement', () async {
       final logs = <String>[];
       await testBuilder(


### PR DESCRIPTION
This PR allows to use a new option `coverage_ignore_file` in the `combining_builder` with this all generated files will have the next comment at the beginning 
```dart
// coverage:ignore-file
```

This is neccessary due to`json_serializable` needs this to allow us exclude the generated files from code coverage. For more info check https://github.com/google/json_serializable.dart/issues/1106