### PR TITLE
Add support for `build_extensions` configuration of builders producing multiple files

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.8
+## 1.3.0
 
 * Add support for `build_extensions` configuration of builders producing multiple files. Eg:
   `build_extensions: { '.dart': ['.stub.dart', '.web.dart', '.vm.dart'] }`

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.8
+
+* Add support for `build_extensions` configuration of builders producing multiple files. Eg:
+  `build_extensions: { '.dart': ['.stub.dart', '.web.dart', '.vm.dart'] }`
+
 ## 1.2.7
 
 * Update the value of the pubspec `repository` field.

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -206,7 +206,7 @@ Map<String, List<String>> validatedBuildExtensionsFrom(
       if (o is! String || (i == 0 && !o.endsWith('.dart'))) {
         throw ArgumentError(
           'Invalid output extension `${entry.value}`. It should be a string '
-          'or a list of strings ending with `.dart`',
+          'or a list of strings with the first ending with `.dart`',
         );
       }
     }

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -200,11 +200,11 @@ Map<String, List<String>> validatedBuildExtensionsFrom(
       );
     }
 
-    final output =
-        (entry.value is Iterable) ? entry.value as Iterable : [entry.value];
+    final output = (entry.value is List) ? entry.value as List : [entry.value];
 
-    for (var o in output) {
-      if (o is! String || !o.endsWith('.dart')) {
+    for (var i = 0; i < output.length; i++) {
+      final o = output[i];
+      if (o is! String || (i == 0 && !o.endsWith('.dart'))) {
         throw ArgumentError(
           'Invalid output extension `${entry.value}`. It should be a string '
           'or a list of strings ending with `.dart`',

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -177,9 +177,8 @@ Map<String, List<String>> validatedBuildExtensionsFrom(
 ) {
   final extensionsOption = optionsMap?.remove('build_extensions');
   if (extensionsOption == null) {
-    // NOTE: defaultExtensions is not validated
-    // Maybe it would make sense to validate it as well instead of returning
-    // it directly. But this would possibly be a breaking change?
+    // defaultExtensions are provided by the builder author, not the end user.
+    // It should be safe to skip validation.
     return defaultExtensions;
   }
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.7
+version: 1.2.8
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.2.8
+version: 1.3.0
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -114,7 +114,7 @@ void main() {
             (e) => e.message,
             'message',
             'Invalid key in build_extensions option: `.txt` should be a '
-                'string with the first ending with `.dart`',
+                'string ending with `.dart`',
           ),
         ),
       );

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -114,7 +114,7 @@ void main() {
             (e) => e.message,
             'message',
             'Invalid key in build_extensions option: `.txt` should be a '
-                'string ending with `.dart`',
+                'string with the first ending with `.dart`',
           ),
         ),
       );
@@ -133,7 +133,7 @@ void main() {
             (e) => e.message,
             'message',
             'Invalid output extension `.out`. It should be a string or a list '
-                'of strings ending with `.dart`',
+                'of strings with the first ending with `.dart`',
           ),
         ),
       );
@@ -152,7 +152,8 @@ void main() {
             (e) => e.message,
             'message',
             'Invalid output extension `[.out, .g.dart]`. It should be a '
-                'string or a list of strings ending with `.dart`',
+                'string or a list of strings with the first ending with '
+                '`.dart`',
           ),
         ),
       );

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -46,11 +46,25 @@ void main() {
 
   group('validatedBuildExtensionsFrom', () {
     test('no option given -> return defaultBuildExtension ', () {
-      final buildEtension = validatedBuildExtensionsFrom({}, {
+      final buildExtension = validatedBuildExtensionsFrom({}, {
         '.dart': ['.foo.dart'],
       });
-      expect(buildEtension, {
+      expect(buildExtension, {
         '.dart': ['.foo.dart'],
+      });
+    });
+
+    test('allows multiple output extensions ', () {
+      final buildExtensions = validatedBuildExtensionsFrom(
+        {
+          'build_extensions': {
+            '.dart': ['.g.dart', '.h.dart']
+          }
+        },
+        {},
+      );
+      expect(buildExtensions, {
+        '.dart': ['.g.dart', '.h.dart'],
       });
     });
 
@@ -104,8 +118,27 @@ void main() {
           isArgumentError.having(
             (e) => e.message,
             'message',
-            'Invalid output extension `.out`. It should be a string ending '
-                'with `.dart`',
+            'Invalid output extension `.out`. It should be a string or a list '
+                'of strings ending with `.dart`',
+          ),
+        ),
+      );
+
+      expect(
+        () => validatedBuildExtensionsFrom(
+          {
+            'build_extensions': {
+              '.dart': ['.g.dart', '.out']
+            }
+          },
+          {},
+        ),
+        throwsA(
+          isArgumentError.having(
+            (e) => e.message,
+            'message',
+            'Invalid output extension `[.g.dart, .out]`. It should be a '
+                'string or a list of strings ending with `.dart`',
           ),
         ),
       );

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -54,7 +54,7 @@ void main() {
       });
     });
 
-    test('allows multiple output extensions ', () {
+    test('allows multiple output extensions', () {
       final buildExtensions = validatedBuildExtensionsFrom(
         {
           'build_extensions': {
@@ -65,6 +65,20 @@ void main() {
       );
       expect(buildExtensions, {
         '.dart': ['.g.dart', '.h.dart'],
+      });
+    });
+
+    test('allows multiple output extensions of various types ', () {
+      final buildExtensions = validatedBuildExtensionsFrom(
+        {
+          'build_extensions': {
+            '.dart': ['.g.dart', '.swagger.json']
+          }
+        },
+        {},
+      );
+      expect(buildExtensions, {
+        '.dart': ['.g.dart', '.swagger.json'],
       });
     });
 
@@ -128,7 +142,7 @@ void main() {
         () => validatedBuildExtensionsFrom(
           {
             'build_extensions': {
-              '.dart': ['.g.dart', '.out']
+              '.dart': ['.out', '.g.dart']
             }
           },
           {},
@@ -137,7 +151,7 @@ void main() {
           isArgumentError.having(
             (e) => e.message,
             'message',
-            'Invalid output extension `[.g.dart, .out]`. It should be a '
+            'Invalid output extension `[.out, .g.dart]`. It should be a '
                 'string or a list of strings ending with `.dart`',
           ),
         ),


### PR DESCRIPTION
The `validatedBuildExtensionsFrom()` in `utils.js` currently rejects `build_extensions` configurations that use a list of strings rather than a single string.

This PR adds support for lists of strings.