### PR TITLE
Fix issue with `isExactlyType` that resulted in unexpected

### DIFF
--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -174,7 +174,17 @@ abstract class TypeChecker {
   bool isExactly(Element element);
 
   /// Returns `true` if representing the exact same type as [staticType].
-  bool isExactlyType(DartType staticType) => isExactly(staticType.element!);
+  ///
+  /// This will always return false for types without a backingclass such as
+  /// `void` or function types.
+  bool isExactlyType(DartType staticType) {
+    var element = staticType.element;
+    if (element != null) {
+      return isExactly(element);
+    } else {
+      return false;
+    }
+  }
 
   /// Returns `true` if representing a super class of [element].
   ///

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -178,7 +178,7 @@ abstract class TypeChecker {
   /// This will always return false for types without a backingclass such as
   /// `void` or function types.
   bool isExactlyType(DartType staticType) {
-    var element = staticType.element;
+    final element = staticType.element;
     if (element != null) {
       return isExactly(element);
     } else {

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -32,6 +32,7 @@ void main() {
   late TypeChecker staticHashMapChecker;
   late TypeChecker staticEnumChecker;
   late LibraryElement core;
+  late LibraryElement core;
 
   // Resolved top-level types from package:source_gen.
   late InterfaceType staticGenerator;
@@ -188,7 +189,7 @@ void main() {
       'isExactlyType',
       () {
         test('should not crash with null element', () {
-          var voidType = core.typeProvider.voidType;
+          final voidType = core.typeProvider.voidType;
           expect(voidType.element, isNull);
           expect(checkMapMixin().isExactlyType(voidType), isFalse);
         });

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -31,6 +31,7 @@ void main() {
   late TypeChecker staticMapMixinChecker;
   late TypeChecker staticHashMapChecker;
   late TypeChecker staticEnumChecker;
+  late LibraryElement core;
 
   // Resolved top-level types from package:source_gen.
   late InterfaceType staticGenerator;
@@ -45,7 +46,6 @@ void main() {
   late InterfaceType staticMyEnumWithMixin;
 
   setUpAll(() async {
-    late LibraryElement core;
     late LibraryElement collection;
     late LibraryReader sourceGen;
     late LibraryElement testSource;
@@ -183,6 +183,17 @@ void main() {
         },
       );
     });
+
+    group(
+      'isExactlyType',
+      () {
+        test('should not crash with null element', () {
+          var voidType = core.typeProvider.voidType;
+          expect(voidType.element, isNull);
+          expect(checkMapMixin().isExactlyType(voidType), isFalse);
+        });
+      },
+    );
 
     group(
       '(MapMixin',

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -32,7 +32,6 @@ void main() {
   late TypeChecker staticHashMapChecker;
   late TypeChecker staticEnumChecker;
   late LibraryElement core;
-  late LibraryElement core;
 
   // Resolved top-level types from package:source_gen.
   late InterfaceType staticGenerator;


### PR DESCRIPTION
"Null check operator used on a null value" errors.