### PR TITLE
Add CHANGELOG entry for TypeChecker fix

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.3.0
 
-* Add support for `build_extensions` configuration of builders producing multiple files. Eg:
+* Add support for `build_extensions` configuration of builders producing
+  multiple files. For example:
   `build_extensions: { '.dart': ['.stub.dart', '.web.dart', '.vm.dart'] }`
+* Avoid throwing when a type without a backing class is checked with
+  `TypeChecker`.
 
 ## 1.2.7
 


### PR DESCRIPTION
Prepares for publishing.

Also reformat the `build_extensions` changelog entry.