### PR TITLE
Include directives in LibraryReader.allElements

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -5,6 +5,8 @@
   `build_extensions: { '.dart': ['.stub.dart', '.web.dart', '.vm.dart'] }`
 * Avoid throwing when a type without a backing class is checked with
   `TypeChecker`.
+* Include imports, exports, and part directives in `LibraryReader.allElements`.
+  This allows `GeneratorForAnnotation` to target annotated directives.
 
 ## 1.2.7
 

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -34,7 +34,13 @@ class LibraryReader {
   }
 
   /// All of the declarations in this library.
-  Iterable<Element> get allElements => [element, ...element.topLevelElements];
+  Iterable<Element> get allElements => [
+        element,
+        ...element.topLevelElements,
+        ...element.libraryImports,
+        ...element.libraryExports,
+        ...element.parts,
+      ];
 
   /// All of the declarations in this library annotated with [checker].
   Iterable<AnnotatedElement> annotatedWith(

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -149,8 +149,8 @@ void main() {
     await testBuilder(
       builder,
       {
-  'a|lib/imported.dart': '',
-  'a|lib/part.dart': 'part of \'file.dart\';',
+        'a|lib/imported.dart': '',
+        'a|lib/part.dart': 'part of \'file.dart\';',
         'a|lib/file.dart': '''
       library;
       @deprecated

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -138,6 +138,46 @@ void main() {
       },
     );
   });
+
+  test('applies to annotated directives', () async {
+    final builder = LibraryBuilder(
+      _StubGenerator<Deprecated>(
+        'Deprecated',
+        (element) => '// ${element.runtimeType}',
+      ),
+    );
+    await testBuilder(
+      builder,
+      {
+  'a|lib/imported.dart': '',
+  'a|lib/part.dart': 'part of \'file.dart\';',
+        'a|lib/file.dart': '''
+      library;
+      @deprecated
+      import 'imported.dart';
+      @deprecated
+      export 'imported.dart';
+      @deprecated
+      part 'part.dart';
+      '''
+      },
+      outputs: {
+        'a|lib/file.g.dart': '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// Generator: Deprecated
+// **************************************************************************
+
+// LibraryImportElementImpl
+
+// LibraryExportElementImpl
+
+// PartElementImpl
+'''
+      },
+    );
+  });
 }
 
 class _StubGenerator<T> extends GeneratorForAnnotation<T> {


### PR DESCRIPTION
Closes #662

Allows targeting annotated imports, exports, or part directives with
`GeneratorForAnnotation`.

A pattern established by Mockito is to annotate the import of the file
that will be generated.
