### PR TITLE
Use prefixed tags for publish config

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   push:
-    tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
+    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:


### PR DESCRIPTION
The auto-publish comment already indicates that the package name prefix
should be used.
