### PR TITLE
Prepare for adding InvalidType, make 'TypeChecker.isAssignableFromType()' null safe.

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+* Make `TypeChecker.isAssignableFromType()` null safe.
+
 ## 1.3.1
 
 * Always use a Uri in `part of` directives (previously a name would be used if

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -167,8 +167,10 @@ abstract class TypeChecker {
       (element is InterfaceElement && element.allSupertypes.any(isExactlyType));
 
   /// Returns `true` if [staticType] can be assigned to this type.
-  bool isAssignableFromType(DartType staticType) =>
-      isAssignableFrom(staticType.element!);
+  bool isAssignableFromType(DartType staticType) {
+    final element = staticType.element;
+    return element != null && isAssignableFrom(element);
+  }
 
   /// Returns `true` if representing the exact same class as [element].
   bool isExactly(Element element);

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.3.1
+version: 1.3.2
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen


### PR DESCRIPTION
Prepares for landing https://dart-review.googlesource.com/c/sdk/+/300181

I had to make this check in cl/529250286, so I guess there is a type without an element that gets passed, most probably the newly added `InvalidType`. Anyway, the code was unsafe.