### PR TITLE
Add a `node` to `InvalidGenerationSourceError`

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.3.3-wip
+## 1.4.0-wip
 
 - Require Dart 3.0
+- Add a `node` argument to `InvalidGenerationSourceError` to allow finding the
+  source location from an `AstNode` over an `Element`.
 
 ## 1.3.2
 

--- a/source_gen/lib/src/span_for_element.dart
+++ b/source_gen/lib/src/span_for_element.dart
@@ -58,7 +58,7 @@ SourceSpan spanForNode(AstNode node) {
   final unit = node.thisOrAncestorOfType<CompilationUnit>()!;
   final element = unit.declaredElement!;
   final contents = element.source.contents.data;
-  final url = element.source.uri;
+  final url = assetToPackageUrl(element.source.uri);
   final file = SourceFile.fromString(contents, url: url);
   return file.span(node.offset, node.offset + node.length);
 }

--- a/source_gen/lib/src/span_for_element.dart
+++ b/source_gen/lib/src/span_for_element.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:source_span/source_span.dart';
 
@@ -50,4 +51,14 @@ SourceSpan spanForElement(Element element, [SourceFile? file]) {
   }
 
   return file.span(element.nameOffset, element.nameOffset + element.nameLength);
+}
+
+/// Returns a source span that spans the location where [node] is written.
+SourceSpan spanForNode(AstNode node) {
+  final unit = node.thisOrAncestorOfType<CompilationUnit>()!;
+  final element = unit.declaredElement!;
+  final contents = element.source.contents.data;
+  final url = element.source.uri;
+  final file = SourceFile.fromString(contents, url: url);
+  return file.span(node.offset, node.offset + node.length);
 }

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.3.3-wip
+version: 1.4.0-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen


### PR DESCRIPTION
Allow attempting to find the source location from an AstNode as an
alternative to finding it from an Element.
