### PR TITLE
Restore a dynamic argument

### DIFF
--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -98,7 +98,9 @@ class LibraryReader {
   /// * `asset`
   ///
   /// May throw [ArgumentError] if it is not possible to resolve a path.
-  Uri pathToUrl(Object toUrlOrString) {
+  Uri pathToUrl(dynamic toUrlOrString) {
+    // TODO: https://github.com/dart-lang/source_gen/issues/672 - Take Object
+    ArgumentError.checkNotNull(toUrlOrString, 'toUrlOrString');
     final to = toUrlOrString is Uri
         ? toUrlOrString
         : Uri.parse(toUrlOrString as String);


### PR DESCRIPTION
Avoid moving a runtime null check to a static null check because some
code locations may be passing a nullable reference which is never null.
