### PR TITLE
Add configuration for not throwing on unresolved annotations

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.4.1-wip
+## 1.5.0-wip
+
+- Add `throwOnUnresolved` configuration to the `GeneratorForAnnotation`
+  constructor.
 
 ## 1.4.0
 

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -54,8 +54,10 @@ abstract class GeneratorForAnnotation<T> extends Generator {
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {
     final values = <String>{};
 
-    for (var annotatedElement in library.annotatedWith(typeChecker,
-        throwOnUnresolved: throwOnUnresolved)) {
+    for (var annotatedElement in library.annotatedWith(
+      typeChecker,
+      throwOnUnresolved: throwOnUnresolved,
+    )) {
       final generatedValue = generateForAnnotatedElement(
         annotatedElement.element,
         annotatedElement.annotation,

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -41,7 +41,12 @@ import 'type_checker.dart';
 /// [T] and use the [Element] to iterate over fields. The [TypeChecker] utility
 /// may be helpful to check which elements have a given annotation.
 abstract class GeneratorForAnnotation<T> extends Generator {
-  const GeneratorForAnnotation();
+  final bool throwOnUnresolved;
+
+  /// By default, this generator will throw if it encounters unresolved
+  /// annotations. You can override this by setting [throwOnUnresolved] to
+  /// `false`.
+  const GeneratorForAnnotation({this.throwOnUnresolved = true});
 
   TypeChecker get typeChecker => TypeChecker.fromRuntime(T);
 
@@ -49,7 +54,8 @@ abstract class GeneratorForAnnotation<T> extends Generator {
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {
     final values = <String>{};
 
-    for (var annotatedElement in library.annotatedWith(typeChecker)) {
+    for (var annotatedElement in library.annotatedWith(typeChecker,
+        throwOnUnresolved: throwOnUnresolved)) {
       final generatedValue = generateForAnnotatedElement(
         annotatedElement.element,
         annotatedElement.annotation,

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.4.1-wip
+version: 1.5.0-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -178,13 +178,60 @@ void main() {
       },
     );
   });
+
+  group('Unresolved annotations', () {
+    test('cause an error by default', () async {
+      final builder = LibraryBuilder(
+        _StubGenerator<Deprecated>(
+          'Deprecated',
+          (element) => '// ${element.displayName}',
+        ),
+      );
+      expect(
+        testBuilder(
+          builder,
+          {
+            'a|lib/file.dart': '''
+      @doesNotExist
+      library foo;
+      ''',
+          },
+          outputs: {},
+        ),
+        throwsA(isA<UnresolvedAnnotationException>()),
+      );
+    });
+
+    test('do not cause an error if disabled', () async {
+      final builder = LibraryBuilder(
+        _StubGenerator<Deprecated>(
+          'Deprecated',
+          (element) => '// ${element.displayName}',
+          throwOnUnresolved: false,
+        ),
+      );
+      expect(
+        testBuilder(
+          builder,
+          {
+            'a|lib/file.dart': '''
+      @doesNotExist
+      library foo;
+      ''',
+          },
+          outputs: {},
+        ),
+        completes,
+      );
+    });
+  });
 }
 
 class _StubGenerator<T> extends GeneratorForAnnotation<T> {
   final String _name;
   final Object? Function(Element) _behavior;
 
-  const _StubGenerator(this._name, this._behavior);
+  const _StubGenerator(this._name, this._behavior, {super.throwOnUnresolved});
 
   @override
   Object? generateForAnnotatedElement(


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_gen/issues/682

This only enables configuration right now, mostly to avoid any change in default behavior. I am open to changing the default too though.