### PR TITLE
Make InvalidGenerationSourceError an Exception

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.4.1-wip
+## 1.5.0-wip
+
+- Rename `InvalidGenerationSourceError` to `InvalidGenerationSource`. Change
+  from a subtype of `Error` to a subtype of `Exception`. This may be breaking if
+  a builder relies on a `on Exception catch` to ignore this error.
 
 ## 1.4.0
 

--- a/source_gen/lib/source_gen.dart
+++ b/source_gen/lib/source_gen.dart
@@ -6,7 +6,8 @@ export 'src/builder.dart'
     show LibraryBuilder, PartBuilder, SharedPartBuilder, defaultFileHeader;
 export 'src/constants/reader.dart' show ConstantReader;
 export 'src/constants/revive.dart' show Revivable;
-export 'src/generator.dart' show Generator, InvalidGenerationSourceError;
+export 'src/generator.dart'
+    show Generator, InvalidGenerationSource, InvalidGenerationSourceError;
 export 'src/generator_for_annotation.dart' show GeneratorForAnnotation;
 export 'src/library.dart' show AnnotatedElement, LibraryReader;
 export 'src/span_for_element.dart' show spanForElement;

--- a/source_gen/lib/src/generator.dart
+++ b/source_gen/lib/src/generator.dart
@@ -32,7 +32,10 @@ abstract class Generator {
 
 typedef InvalidGenerationSourceError = InvalidGenerationSource;
 
-/// May be thrown by generators during [Generator.generate].
+/// A description of a problem in the source input to code generation.
+///
+/// May be thrown by generators during [Generator.generate] to communicate a
+/// problem to the codegen user.
 class InvalidGenerationSource implements Exception {
   /// What failure occurred.
   final String message;

--- a/source_gen/lib/src/generator.dart
+++ b/source_gen/lib/src/generator.dart
@@ -30,8 +30,10 @@ abstract class Generator {
   String toString() => runtimeType.toString();
 }
 
+typedef InvalidGenerationSourceError = InvalidGenerationSource;
+
 /// May be thrown by generators during [Generator.generate].
-class InvalidGenerationSourceError extends Error {
+class InvalidGenerationSource implements Exception {
   /// What failure occurred.
   final String message;
 
@@ -52,7 +54,7 @@ class InvalidGenerationSourceError extends Error {
   /// code, or if the location was passed with [element].
   final AstNode? node;
 
-  InvalidGenerationSourceError(
+  InvalidGenerationSource(
     this.message, {
     this.todo = '',
     this.element,

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.4.1-wip
+version: 1.5.0-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen


### PR DESCRIPTION
See https://github.com/dart-lang/build/issues/3585

Rename to `InvalidGenerationSource` and change to a subtype of
`Exception`. This class is not thrown to indicate a programming error in
the code that is running, it is thrown to indicate an error in the code
under analysis. It was originally implemented without a super type and
the name ending in "Error" was not specifically discussed, but it was
intended to convey an "error in build input", not an error in the
builder implementation (where it is thrown). Later a lint required it to
be a subtype of either `Error` or `Exception`, and the `Error` supertype
was chosen without discussion because of the name, even though it's not
thrown as an `Error` in the sense where that distinction matters.

Add a type alias for the exception with the old name. This can be
deprecated whenever we have the bandwidth to handle the cleanup, but it
will not be deprecated immediately.

Change from `extends Error` to `implements Exception`. This is
technically breaking, but it is unlikely to make a significant impact in
real world usage scenarios. It may impact how the error surfaces to end
users in some places.
