### PR TITLE
Document generateForAnnotatedElement deduplication

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.1-wip
+
+- Document deduplication behavior for the output of
+  `GeneratorForAnnotation.generateForAnnotatedElement`.
+
 ## 1.5.0
 
 - Add `throwOnUnresolved` configuration to the `GeneratorForAnnotation`

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -79,7 +79,13 @@ abstract class GeneratorForAnnotation<T> extends Generator {
   ///
   /// Supported return values include a single [String] or multiple [String]
   /// instances within an [Iterable] or [Stream]. It is also valid to return a
-  /// [Future] of [String], [Iterable], or [Stream].
+  /// [Future] of [String], [Iterable], or [Stream]. When multiple values are
+  /// returned through an iterable or stream they will be dedeuplicated.
+  /// Typically each value will be an independent unit of code and the
+  /// deduplication prevents re-defining the same member multiple times. For
+  /// example if multiple annotated elements may need a specific utility method
+  /// available it can be output for each one, and the single deduplicated
+  /// definition can be shared.
   ///
   /// Implementations should return `null` when no content is generated. Empty
   /// or whitespace-only [String] instances are also ignored.

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -80,7 +80,7 @@ abstract class GeneratorForAnnotation<T> extends Generator {
   /// Supported return values include a single [String] or multiple [String]
   /// instances within an [Iterable] or [Stream]. It is also valid to return a
   /// [Future] of [String], [Iterable], or [Stream]. When multiple values are
-  /// returned through an iterable or stream they will be dedeuplicated.
+  /// returned through an iterable or stream they will be deduplicated.
   /// Typically each value will be an independent unit of code and the
   /// deduplication prevents re-defining the same member multiple times. For
   /// example if multiple annotated elements may need a specific utility method

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.5.0
+version: 1.5.1-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen


### PR DESCRIPTION
Closes #648

Expand the doc about the return type to explain that when there are
multiple output strings they are deduplicated, allowing each annotated
element to output content that they may need to share with other
elements.
