### PR TITLE
Support path with parenthesis

### DIFF
--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -85,8 +85,7 @@ class CombiningBuilder implements Builder {
     final pattern = buildStep.inputId
         .changeExtension('.*$_partFiles')
         .path
-        .replaceAll('(', r'\(')
-        .replaceAll(')', r'\)');
+        .replaceAllMapped(RegExp(r'\((.*)\)'), (match) => '\\(${match[1]}\\)');
 
     final inputBaseName =
         p.basenameWithoutExtension(buildStep.inputId.pathSegments.last);

--- a/source_gen/lib/builder.dart
+++ b/source_gen/lib/builder.dart
@@ -82,7 +82,11 @@ class CombiningBuilder implements Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
     // Pattern used for `findAssets`, which must be glob-compatible
-    final pattern = buildStep.inputId.changeExtension('.*$_partFiles').path;
+    final pattern = buildStep.inputId
+        .changeExtension('.*$_partFiles')
+        .path
+        .replaceAll('(', r'\(')
+        .replaceAll(')', r'\)');
 
     final inputBaseName =
         p.basenameWithoutExtension(buildStep.inputId.pathSegments.last);


### PR DESCRIPTION
Parenthesized path like `(this)`
---
I am creating a nextjs-like file-based routing system. It contains a path grouping mechanism that uses the `(parenthesized)` path. `source_gen` currently depends on `glob`, and the `glob` uses the regular expression. In regular expression, `()` works as a capture. Thus, if the path contains the `(this)`-like path, `source_gen` throws an error. 

![image](https://github.com/dart-lang/source_gen/assets/162911824/9a0e49d9-2d6a-4368-b0b8-65a2eb14eb33)

To support this path, I change the code that appends the escaping character `\` before the parenthesis. 

This is a one-line change, so I did not add the test, modify the changelog, or change the pubspec package version. If those are required, please let me know. 

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
