### PR TITLE
Revive to the object's `variableElement` if available

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -4,6 +4,7 @@
   `GeneratorForAnnotation.generateForAnnotatedElement`.
 - Support all the glob quotes.
 - Require Dart 3.4.0
+- Revive to the object's `variableElement` if available
 
 ## 1.5.0
 

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -20,6 +20,21 @@ import '../utils.dart';
 /// Dart source code (such as referencing private constructors). It is up to the
 /// build tool(s) using this library to surface error messages to the user.
 Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
+  final variableElement = object.variable;
+  if (variableElement != null &&
+      variableElement.isConst &&
+      variableElement.isPublic) {
+    final url = Uri.parse(urlOfElement(variableElement)).removeFragment();
+    if (variableElement.enclosingElement
+        case TypeDefiningElement enclosingElement?) {
+      return Revivable._(
+        source: url,
+        accessor: '${enclosingElement.name}.${variableElement.name}',
+      );
+    }
+    return Revivable._(source: url, accessor: variableElement.name);
+  }
+
   final objectType = object.type;
   Element? element = objectType!.alias?.element;
   if (element == null) {

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -26,7 +26,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
       variableElement.isPublic) {
     final url = Uri.parse(urlOfElement(variableElement)).removeFragment();
     if (variableElement.enclosingElement
-        case TypeDefiningElement enclosingElement?) {
+        case final TypeDefiningElement enclosingElement?) {
       return Revivable._(
         source: url,
         accessor: '${enclosingElement.name}.${variableElement.name}',

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -227,6 +227,7 @@ void main() {
         @_privateField
         @Wrapper(_privateFunction)
         @ProcessStartMode.normal
+        @ExtensionTypeWithStaticField.staticField
         class Example {}
 
         class Int64Like implements Int64LikeBase{
@@ -296,6 +297,10 @@ void main() {
         }
 
         void _privateFunction() {}
+
+        extension type const ExtensionTypeWithStaticField._(int _) {
+          static const staticField = ExtensionTypeWithStaticField._(1);
+        }
       ''',
         (resolver) async => (await resolver.findLibraryByName('test_lib'))!,
       );
@@ -392,6 +397,12 @@ void main() {
       expect(staticFieldWithPrivateImpl.accessor, 'ProcessStartMode.normal');
       expect(staticFieldWithPrivateImpl.isPrivate, isFalse);
       expect(staticFieldWithPrivateImpl.source.fragment, isEmpty);
+    });
+
+    test('should decode static fields on extension types', () {
+      final fieldOnly = constants[14].revive();
+      expect(fieldOnly.source.fragment, isEmpty);
+      expect(fieldOnly.accessor, 'ExtensionTypeWithStaticField.staticField');
     });
   });
 }


### PR DESCRIPTION
Variables have been tracked on DartObject since https://dart.googlesource.com/sdk/+/54b7f4b72a1701f8f9a0334c94ce6f59732bd261. This change uses the variable in the reviver if it exists. I believe the existing tests in https://github.com/dart-lang/source_gen/blob/master/source_gen/test/constants_test.dart already cover this, but lmk if you'd like any additional tests

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
