### PR TITLE
Import package:analyzer/source/source.dart instead of internal.

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -4,6 +4,7 @@
   `GeneratorForAnnotation.generateForAnnotatedElement`.
 - Support all the glob quotes.
 - Require Dart 3.4.0
+- Require `analyzer: '>=6.4.0 <7.0.0'`
 
 ## 1.5.0
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  analyzer: '>=5.2.0 <7.0.0'
+  analyzer: '>=6.4.0 <7.0.0'
   async: ^2.5.0
   build: ^2.1.0
   dart_style: ^2.0.0

--- a/source_gen/test/library/path_to_url_test.dart
+++ b/source_gen/test/library/path_to_url_test.dart
@@ -4,7 +4,7 @@
 
 // Increase timeouts on this test which resolves source code and can be slow.
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/source/source.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
Preparation for https://dart-review.googlesource.com/c/sdk/+/369560

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
