### PR TITLE
Change formatOutput function to accept a language version to parse with

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,5 +1,10 @@
-## 1.5.1-wip
+## 2.0.0-wip
 
+- **Breaking Change**: Change `formatOutput` function to accept a language
+  version parameter.
+- **Formatting Change**: Generated code will no longer apply any fixes by
+  default (previously it would apply the single cascades statements fix). The
+  new formatter will not support applying fixes.
 - Document deduplication behavior for the output of
   `GeneratorForAnnotation.generateForAnnotatedElement`.
 - Support all the glob quotes.

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -313,21 +313,13 @@ class LibraryBuilder extends _Builder {
   /// libraries.
   LibraryBuilder(
     Generator generator, {
-    String Function(String, Version) formatOutput = _defaultFormatOutput,
-    String generatedExtension = '.g.dart',
-    List<String> additionalOutputExtensions = const [],
-    String? header,
-    bool allowSyntaxErrors = false,
-    BuilderOptions? options,
-  }) : super(
-          [generator],
-          formatOutput: formatOutput,
-          generatedExtension: generatedExtension,
-          additionalOutputExtensions: additionalOutputExtensions,
-          header: header,
-          allowSyntaxErrors: allowSyntaxErrors,
-          options: options,
-        );
+    super.formatOutput,
+    super.generatedExtension,
+    super.additionalOutputExtensions,
+    super.header,
+    super.allowSyntaxErrors,
+    super.options,
+  }) : super([generator]);
 }
 
 Stream<GeneratedOutput> _generate(

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import 'generated_output.dart';
 import 'generator.dart';
@@ -18,7 +19,10 @@ import 'utils.dart';
 /// A [Builder] wrapping on one or more [Generator]s.
 class _Builder extends Builder {
   /// Function that determines how the generated code is formatted.
-  final String Function(String) formatOutput;
+  ///
+  /// The `languageVersion` is the version to parse the file with, but it may be
+  /// overridden using a language version comment in the file.
+  final String Function(String code, Version languageVersion) formatOutput;
 
   /// The generators run for each targeted library.
   final List<Generator> _generators;
@@ -43,7 +47,7 @@ class _Builder extends Builder {
   /// [options] to allow output files to be generated into a different directory
   _Builder(
     this._generators, {
-    String Function(String code)? formatOutput,
+    this.formatOutput = _defaultFormatOutput,
     String generatedExtension = '.g.dart',
     List<String> additionalOutputExtensions = const [],
     String? header,
@@ -57,7 +61,6 @@ class _Builder extends Builder {
             ...additionalOutputExtensions,
           ],
         }),
-        formatOutput = formatOutput ?? _formatter.format,
         _header = (header ?? defaultFileHeader).trim() {
     if (_generatedExtension.isEmpty || !_generatedExtension.startsWith('.')) {
       throw ArgumentError.value(
@@ -165,7 +168,8 @@ class _Builder extends Builder {
     var genPartContent = contentBuffer.toString();
 
     try {
-      genPartContent = formatOutput(genPartContent);
+      genPartContent =
+          formatOutput(genPartContent, library.languageVersion.effective);
     } catch (e, stack) {
       log.severe(
         '''
@@ -299,7 +303,7 @@ class LibraryBuilder extends _Builder {
   /// should be indicated in [additionalOutputExtensions].
   ///
   /// [formatOutput] is called to format the generated code. Defaults to
-  /// [DartFormatter.format].
+  /// using the standard [DartFormatter].
   ///
   /// [header] is used to specify the content at the top of each generated file.
   /// If `null`, the content of [defaultFileHeader] is used.
@@ -309,7 +313,7 @@ class LibraryBuilder extends _Builder {
   /// libraries.
   LibraryBuilder(
     Generator generator, {
-    String Function(String code)? formatOutput,
+    String Function(String, Version) formatOutput = _defaultFormatOutput,
     String generatedExtension = '.g.dart',
     List<String> additionalOutputExtensions = const [],
     String? header,
@@ -381,9 +385,10 @@ Future<bool> _hasAnyTopLevelAnnotations(
   return false;
 }
 
-final _formatter = DartFormatter(fixes: [StyleFix.singleCascadeStatements]);
-
 const defaultFileHeader = '// GENERATED CODE - DO NOT MODIFY BY HAND';
+
+String _defaultFormatOutput(String code, Version version) =>
+    DartFormatter(languageVersion: version).format(code);
 
 final _headerLine = '// '.padRight(77, '*');
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 1.5.1-wip
+version: 2.0.0-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen
@@ -12,9 +12,10 @@ dependencies:
   analyzer: ^6.4.0
   async: ^2.5.0
   build: ^2.1.0
-  dart_style: ^2.0.0
+  dart_style: ^2.3.7
   glob: ^2.0.0
   path: ^1.8.0
+  pub_semver: ^2.1.4
   source_span: ^1.8.0
   yaml: ^3.0.0
 

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -824,7 +824,7 @@ foo generated content
       PartBuilder(
         [const UnformattedCodeGenerator()],
         '.foo.dart',
-        formatOutput: (s) => s,
+        formatOutput: (s, _) => s,
       ),
       {'$_pkgName|lib/a.dart': 'library a; part "a.foo.dart";'},
       generateFor: {'$_pkgName|lib/a.dart'},
@@ -842,7 +842,7 @@ foo generated content
       PartBuilder(
         [const UnformattedCodeGenerator()],
         '.foo.dart',
-        formatOutput: (_) => customOutput,
+        formatOutput: (_, __) => customOutput,
       ),
       {'$_pkgName|lib/a.dart': 'library a; part "a.foo.dart";'},
       generateFor: {'$_pkgName|lib/a.dart'},
@@ -938,7 +938,7 @@ Map<String, String> _createPackageStub({
 PartBuilder _unformattedLiteral([String? content]) => PartBuilder(
       [_StubGenerator('Literal', () => content)],
       '.foo.dart',
-      formatOutput: (s) => s,
+      formatOutput: (s, _) => s,
     );
 
 class _StubGenerator implements Generator {

--- a/source_gen/test/src/unformatted_code_generator.dart
+++ b/source_gen/test/src/unformatted_code_generator.dart
@@ -13,17 +13,9 @@ class UnformattedCodeGenerator extends Generator {
 
   static const formattedCode = '''
 void hello() => print('hello');
-
-void x() {
-  <String>[].add('y');
-}
 ''';
 
   static const unformattedCode = '''
 void hello ()=>  print('hello');
-
-void x() {
-  <String>[]..add('y');
-}
 ''';
 }


### PR DESCRIPTION
Updates to the latest dart_style version and passes in a language version. This is in preparation for the tall style formatter which will require a language version to work properly.

- This is a breaking change because the `formatOutput` callback now needs to accept a language version.
- Also drops the default fix for single cascades, fixes will no longer be supported in dart_style.