### PR TITLE
Revert "Revive to the object's `variableElement` if available (#713)"

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Document deduplication behavior for the output of
   `GeneratorForAnnotation.generateForAnnotatedElement`.
 - Support all the glob quotes.
-- Revive to the object's `variableElement` if available
 - Require `analyzer: ^6.9.0`
 - Require Dart 3.5.0
 

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -23,21 +23,6 @@ import '../utils.dart';
 /// Dart source code (such as referencing private constructors). It is up to the
 /// build tool(s) using this library to surface error messages to the user.
 Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
-  final variableElement = object.variable;
-  if (variableElement != null &&
-      variableElement.isConst &&
-      variableElement.isPublic) {
-    final url = Uri.parse(urlOfElement(variableElement)).removeFragment();
-    if (variableElement.enclosingElement
-        case final TypeDefiningElement enclosingElement?) {
-      return Revivable._(
-        source: url,
-        accessor: '${enclosingElement.name}.${variableElement.name}',
-      );
-    }
-    return Revivable._(source: url, accessor: variableElement.name);
-  }
-
   final objectType = object.type;
   Element? element = objectType!.alias?.element;
   if (element == null) {

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -227,7 +227,6 @@ void main() {
         @_privateField
         @Wrapper(_privateFunction)
         @ProcessStartMode.normal
-        @ExtensionTypeWithStaticField.staticField
         class Example {}
 
         class Int64Like implements Int64LikeBase{
@@ -297,10 +296,6 @@ void main() {
         }
 
         void _privateFunction() {}
-
-        extension type const ExtensionTypeWithStaticField._(int _) {
-          static const staticField = ExtensionTypeWithStaticField._(1);
-        }
       ''',
         (resolver) async => (await resolver.findLibraryByName('test_lib'))!,
       );
@@ -397,12 +392,6 @@ void main() {
       expect(staticFieldWithPrivateImpl.accessor, 'ProcessStartMode.normal');
       expect(staticFieldWithPrivateImpl.isPrivate, isFalse);
       expect(staticFieldWithPrivateImpl.source.fragment, isEmpty);
-    });
-
-    test('should decode static fields on extension types', () {
-      final fieldOnly = constants[14].revive();
-      expect(fieldOnly.source.fragment, isEmpty);
-      expect(fieldOnly.accessor, 'ExtensionTypeWithStaticField.staticField');
     });
   });
 }


### PR DESCRIPTION
This reverts commit ac1837fdd1ba6eed236082c88537fdb8c619b1f4, due to it breaking mockito.
