### PR TITLE
`feature:` Optionally omit generated description comments in output

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.1.0-wip
-
-- `LibraryBuilder`, `PartBuilder`, and `SharedPartBuilder` now take an optional `writeDescriptions` boolean. When set to `false`, headers and generator descriptions for the files will not be included in the builder output.
-
 ## 2.0.0-wip
 
 - **Breaking Change**: Change `formatOutput` function to accept a language
@@ -14,6 +10,7 @@
 - Support all the glob quotes.
 - Require `analyzer: ^6.9.0`
 - Require Dart 3.5.0
+- `LibraryBuilder`, `PartBuilder`, and `SharedPartBuilder` now take an optional `writeDescriptions` boolean. When set to `false`, headers and generator descriptions for the files will not be included in the builder output.
 
 ## 1.5.0
 

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0-wip
+- `LibraryBuilder`, `PartBuilder`, `SharedPartBuilder`, can now take an optional `writeDescriptions` boolean. When set to `false`, headers and generator descriptions for the files will not be included in the builder output.
+
 ## 2.0.0-wip
 
 - **Breaking Change**: Change `formatOutput` function to accept a language

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.1.0-wip
-- `LibraryBuilder`, `PartBuilder`, `SharedPartBuilder`, can now take an optional `writeDescriptions` boolean. When set to `false`, headers and generator descriptions for the files will not be included in the builder output.
+- `LibraryBuilder`, `PartBuilder`, and `SharedPartBuilder` now take an optional `writeDescriptions` boolean. When set to `false`, headers and generator descriptions for the files will not be included in the builder output.
 
 ## 2.0.0-wip
 

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.1.0-wip
+
 - `LibraryBuilder`, `PartBuilder`, and `SharedPartBuilder` now take an optional `writeDescriptions` boolean. When set to `false`, headers and generator descriptions for the files will not be included in the builder output.
 
 ## 2.0.0-wip

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -227,6 +227,12 @@ class SharedPartBuilder extends _Builder {
   ///
   /// [allowSyntaxErrors] indicates whether to allow syntax errors in input
   /// libraries.
+  ///
+  /// [writeDescriptions] adds comments to the output used to separate the
+  /// sections of the file generated from different generators, and reveals
+  /// which generator produced the following output.
+  /// If `null`, [writeDescriptions] is set to true which is the default value.
+  /// If [writeDescriptions] is false, no generator descriptions are added.
   SharedPartBuilder(
     super.generators,
     String partId, {
@@ -274,9 +280,11 @@ class PartBuilder extends _Builder {
   /// [formatOutput] is called to format the generated code. Defaults to
   /// [DartFormatter.format].
   ///
-  /// If [writeDescriptions] is false, then no generated descriptions will be
-  /// embeded into the generated out file. The default is true, which includes
-  /// the name of the dart files/parts/libraries which were used to generate.
+  /// [writeDescriptions] adds comments to the output used to separate the
+  /// sections of the file generated from different generators, and reveals
+  /// which generator produced the following output.
+  /// If `null`, [writeDescriptions] is set to true which is the default value.
+  /// If [writeDescriptions] is false, no generator descriptions are added.
   ///
   /// [header] is used to specify the content at the top of each generated file.
   /// If `null`, the content of [defaultFileHeader] is used.
@@ -318,6 +326,12 @@ class LibraryBuilder extends _Builder {
   ///
   /// [formatOutput] is called to format the generated code. Defaults to
   /// using the standard [DartFormatter].
+  ///
+  /// [writeDescriptions] adds comments to the output used to separate the
+  /// sections of the file generated from different generators, and reveals
+  /// which generator produced the following output.
+  /// If `null`, [writeDescriptions] is set to true which is the default value.
+  /// If [writeDescriptions] is false, no generator descriptions are added.
   ///
   /// [header] is used to specify the content at the top of each generated file.
   /// If `null`, the content of [defaultFileHeader] is used.

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -35,6 +35,9 @@ class _Builder extends Builder {
 
   final String _header;
 
+  /// Whether to include or emit the gen part descriptions. Defaults to true.
+  final bool _writeDescriptions;
+
   /// Whether to allow syntax errors in input libraries.
   final bool allowSyntaxErrors;
 
@@ -51,6 +54,7 @@ class _Builder extends Builder {
     String generatedExtension = '.g.dart',
     List<String> additionalOutputExtensions = const [],
     String? header,
+    bool? writeDescriptions,
     this.allowSyntaxErrors = false,
     BuilderOptions? options,
   })  : _generatedExtension = generatedExtension,
@@ -61,6 +65,7 @@ class _Builder extends Builder {
             ...additionalOutputExtensions,
           ],
         }),
+        _writeDescriptions = (writeDescriptions ?? true),
         _header = (header ?? defaultFileHeader).trim() {
     if (_generatedExtension.isEmpty || !_generatedExtension.startsWith('.')) {
       throw ArgumentError.value(
@@ -153,16 +158,19 @@ class _Builder extends Builder {
     }
 
     for (var item in generatedOutputs) {
-      contentBuffer
-        ..writeln()
-        ..writeln(_headerLine)
-        ..writeAll(
-          LineSplitter.split(item.generatorDescription)
-              .map((line) => '// $line\n'),
-        )
-        ..writeln(_headerLine)
-        ..writeln()
-        ..writeln(item.output);
+      if (_writeDescriptions) {
+        contentBuffer
+          ..writeln()
+          ..writeln(_headerLine)
+          ..writeAll(
+            LineSplitter.split(item.generatorDescription)
+                .map((line) => '// $line\n'),
+          )
+          ..writeln(_headerLine)
+          ..writeln();
+      }
+
+      contentBuffer.writeln(item.output);
     }
 
     var genPartContent = contentBuffer.toString();
@@ -225,6 +233,7 @@ class SharedPartBuilder extends _Builder {
     super.formatOutput,
     super.additionalOutputExtensions,
     super.allowSyntaxErrors,
+    super.writeDescriptions,
   }) : super(
           generatedExtension: '.$partId.g.part',
           header: '',
@@ -265,6 +274,10 @@ class PartBuilder extends _Builder {
   /// [formatOutput] is called to format the generated code. Defaults to
   /// [DartFormatter.format].
   ///
+  /// If [writeDescriptions] is false, then no generated descriptions will be
+  /// embeded into the generated out file. The default is true, which includes
+  /// the name of the dart files/parts/libraries which were used to generate.
+  ///
   /// [header] is used to specify the content at the top of each generated file.
   /// If `null`, the content of [defaultFileHeader] is used.
   /// If [header] is an empty `String` no header is added.
@@ -279,6 +292,7 @@ class PartBuilder extends _Builder {
     String generatedExtension, {
     super.formatOutput,
     super.additionalOutputExtensions,
+    super.writeDescriptions,
     super.header,
     super.allowSyntaxErrors,
     super.options,
@@ -316,6 +330,7 @@ class LibraryBuilder extends _Builder {
     super.formatOutput,
     super.generatedExtension,
     super.additionalOutputExtensions,
+    super.writeDescriptions,
     super.header,
     super.allowSyntaxErrors,
     super.options,

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -65,7 +65,7 @@ class _Builder extends Builder {
             ...additionalOutputExtensions,
           ],
         }),
-        _writeDescriptions = (writeDescriptions ?? true),
+        _writeDescriptions = writeDescriptions ?? true,
         _header = (header ?? defaultFileHeader).trim() {
     if (_generatedExtension.isEmpty || !_generatedExtension.startsWith('.')) {
       throw ArgumentError.value(

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 2.1.0-wip
+version: 2.0.0-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 2.0.0-wip
+version: 2.1.0-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -84,6 +84,25 @@ void main() {
     );
   });
 
+  test('Omits generated comments if writeDescriptions is explicitly false',
+      () async {
+    final srcs = _createPackageStub();
+    final builder = LibraryBuilder(
+      const CommentGenerator(),
+      header: '',
+      writeDescriptions: false,
+    );
+    await testBuilder(
+      builder,
+      srcs,
+      generateFor: {'$_pkgName|lib/test_lib.dart'},
+      outputs: {
+        '$_pkgName|lib/test_lib.g.dart':
+            decodedMatches(isNot(startsWith('// ***'))),
+      },
+    );
+  });
+
   test('Expect no error when multiple generators used on nonstandalone builder',
       () async {
     expect(

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -87,21 +87,6 @@ void main() {
   test('Omits generated comments if writeDescriptions is explicitly false',
       () async {
     final srcs = _createPackageStub();
-    final builder = LibraryBuilder(
-      const CommentGenerator(),
-      writeDescriptions: false,
-    );
-
-    // With default header
-    await testBuilder(
-      builder,
-      srcs,
-      generateFor: {'$_pkgName|lib/test_lib.dart'},
-      outputs: {
-        '$_pkgName|lib/test_lib.g.dart':
-            decodedMatches(startsWith(defaultFileHeader)),
-      },
-    );
 
     // Explicitly empty header
     final builderEmptyHeader = LibraryBuilder(

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -89,16 +89,65 @@ void main() {
     final srcs = _createPackageStub();
     final builder = LibraryBuilder(
       const CommentGenerator(),
-      header: '',
       writeDescriptions: false,
     );
+
+    // With default header
     await testBuilder(
       builder,
       srcs,
       generateFor: {'$_pkgName|lib/test_lib.dart'},
       outputs: {
         '$_pkgName|lib/test_lib.g.dart':
-            decodedMatches(isNot(startsWith('// ***'))),
+            decodedMatches(startsWith(defaultFileHeader)),
+      },
+    );
+
+    // Explicitly empty header
+    final builderEmptyHeader = LibraryBuilder(
+      const CommentGenerator(),
+      header: '',
+      writeDescriptions: false,
+    );
+
+    const expected = '''
+// Code for "class Person"
+// Code for "class Customer"
+''';
+
+    await testBuilder(
+      builderEmptyHeader,
+      srcs,
+      generateFor: {'$_pkgName|lib/test_lib.dart'},
+      outputs: {
+        '$_pkgName|lib/test_lib.g.dart': decodedMatches(startsWith(expected)),
+      },
+    );
+  });
+
+  test('When writeDescriptions is true, generated comments are present',
+      () async {
+    final srcs = _createPackageStub();
+
+    // Null value for writeDescriptions resolves to true
+    final builder = LibraryBuilder(
+      const CommentGenerator(),
+      // We omit header to inspect the generator descriptions
+      header: '',
+    );
+
+    const expected = '''
+// **************************************************************************
+// CommentGenerator
+// **************************************************************************
+''';
+
+    await testBuilder(
+      builder,
+      srcs,
+      generateFor: {'$_pkgName|lib/test_lib.dart'},
+      outputs: {
+        '$_pkgName|lib/test_lib.g.dart': decodedMatches(contains(expected)),
       },
     );
   });


### PR DESCRIPTION
Related: https://github.com/dart-lang/source_gen/issues/706.

This PR adds an optional `bool? writesDescriptions` field to the `_Builder` base class constructor.
By default, it is `true`, but if explicitly set to `false`, the generated description comments will not be included
in the generated output.

See related link for my use-case. This will be useful so that _any_ file can be generated with this tool for Dart.

Checklist
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've accepted the [Google Individual Contributor License Agreement](https://cla.developers.google.com/about/google-individual) (CLA)
- [x] I've written a new test for this new feature.
