### PR TITLE
Don't use workspace resolution for example

### DIFF
--- a/example_usage/pubspec.yaml
+++ b/example_usage/pubspec.yaml
@@ -1,6 +1,8 @@
 name: source_gen_example_usage
 publish_to: none
-resolution: workspace
+# TODO(https://github.com/dart-lang/build/issues/3721) - build_runner broken by
+# workspace resolution.
+# resolution: workspace
 
 environment:
   sdk: ^3.6.0-270.0.dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,9 @@ environment:
 workspace:
   - source_gen
   - example
-  - example_usage
+  # TODO(https://github.com/dart-lang/build/issues/3721) - build_runner broken
+  # by workspace resolution.
+  # - example_usage
   - _test_annotations
 
 dev_dependencies:


### PR DESCRIPTION
Use non-workspace resolution because `build_runner` does not support
packages where the `pubspec.lock` file is not at the package root.

See https://github.com/dart-lang/build/issues/3721
