### PR TITLE
Read parts with the defining compilation unit

### DIFF
--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -37,8 +37,10 @@ class LibraryReader {
   Iterable<Element> get allElements => [
         element,
         ...element.topLevelElements,
-        ...element.definingCompilationUnit.libraryImports,
-        ...element.definingCompilationUnit.libraryExports,
+        // ignore: deprecated_member_use
+        ...element.libraryImports,
+        // ignore: deprecated_member_use
+        ...element.libraryExports,
         ...element.definingCompilationUnit.parts,
       ];
 

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -37,12 +37,9 @@ class LibraryReader {
   Iterable<Element> get allElements => [
         element,
         ...element.topLevelElements,
-        // ignore: deprecated_member_use
-        ...element.libraryImports,
-        // ignore: deprecated_member_use
-        ...element.libraryExports,
-        // ignore: deprecated_member_use
-        ...element.parts,
+        ...element.definingCompilationUnit.libraryImports,
+        ...element.definingCompilationUnit.libraryExports,
+        ...element.definingCompilationUnit.parts,
       ];
 
   /// All of the declarations in this library annotated with [checker].


### PR DESCRIPTION
The direct read of parts from the library element is deprecated.
Retain ignores for reading imports and exports since they
will be restored without a deprecation.

Unblocks https://dart-review.googlesource.com/c/sdk/+/388643
