### PR TITLE
Keep generated file comments on the first line

### DIFF
--- a/example_usage/lib/library_source.info.dart
+++ b/example_usage/lib/library_source.info.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 // **************************************************************************
 // MemberCountLibraryGenerator

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1-WIP
+
+- Keep `// GENERATED FILE` comments on the first line.
+
 ## 2.0.0
 
 - **Breaking Change**: Change `formatOutput` function to accept a language

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -414,7 +414,13 @@ String _defaultFormatOutput(String code, Version version) =>
 
 /// Prefixes a dart format width and formats [code].
 String _defaultFormatUnit(String code, Version version) {
-  code = '$dartFormatWidth\n$code';
+  if (code.startsWith('$defaultFileHeader\n')) {
+    code = '$defaultFileHeader\n'
+        '$dartFormatWidth\n'
+        '${code.substring(defaultFileHeader.length)}';
+  } else {
+    code = '$dartFormatWidth\n$code';
+  }
   return _defaultFormatOutput(code, version);
 }
 

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -434,7 +434,8 @@ String _defaultFormatOutput(String code, Version version) =>
 /// Prefixes a dart format width and formats [code].
 String _defaultFormatUnit(String code, Version version) {
   if (code.startsWith('$defaultFileHeader\n')) {
-    code = '$defaultFileHeader\n'
+    code =
+        '$defaultFileHeader\n'
         '$dartFormatWidth\n'
         '${code.substring(defaultFileHeader.length)}';
   } else {

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 2.0.0
+version: 2.0.1-WIP
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -1067,8 +1067,8 @@ final int foo = 42
 ''';
 
 const _testGenPartContent = '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 part of 'test_lib.dart';
 
@@ -1081,8 +1081,8 @@ part of 'test_lib.dart';
 ''';
 
 const _testGenPartContentForLibrary = '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 part of 'test_lib.dart';
 
@@ -1094,8 +1094,8 @@ part of 'test_lib.dart';
 ''';
 
 const _testGenStandaloneContent = '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 // **************************************************************************
 // CommentGenerator
@@ -1106,8 +1106,8 @@ $dartFormatWidth
 ''';
 
 const _testGenPartContentForClassesAndLibrary = '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 part of 'test_lib.dart';
 
@@ -1121,8 +1121,8 @@ part of 'test_lib.dart';
 ''';
 
 const _testGenNoLibrary = '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 part of 'test_lib.dart';
 

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -44,8 +44,8 @@ void main() {
       _inputMap,
       outputs: {
         'a|lib/file.g.dart': '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 // **************************************************************************
 // Generator: Repeating
@@ -129,8 +129,8 @@ $dartFormatWidth
       },
       outputs: {
         'a|lib/file.g.dart': '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 // **************************************************************************
 // Generator: Deprecated
@@ -166,8 +166,8 @@ $dartFormatWidth
       },
       outputs: {
         'a|lib/file.g.dart': '''
-$dartFormatWidth
 // GENERATED CODE - DO NOT MODIFY BY HAND
+$dartFormatWidth
 
 // **************************************************************************
 // Generator: Deprecated


### PR DESCRIPTION
Let linquist continue to find the generated file marker on the first
line, the dart format width comment is allowed to be on any line.

Look for the generated file line exactly and when it starts the file
insert the dart format comment following it.
