### PR TITLE
skip files with only known annotation names

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -6,6 +6,8 @@
   For questions please use https://github.com/dart-lang/build/discussions.
 - Updated the minimum package versions for a number of dependencies.
 - Require Dart 3.7.0
+- Update the GeneratorForAnnotation optimization to skip files with well known
+  annotation names such as `override`, `Deprecated`, and `pragma`.
 
 ## 2.0.0
 

--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0-wip
+
+- Update the GeneratorForAnnotation optimization to skip files with well known
+  annotation names such as `override`, `Deprecated`, and `pragma`.
+
 ## 3.0.0-dev
 
 - **Breaking Change**: use the new `element2` APIs in `analyzer`. Builders that
@@ -6,8 +11,6 @@
   For questions please use https://github.com/dart-lang/build/discussions.
 - Updated the minimum package versions for a number of dependencies.
 - Require Dart 3.7.0
-- Update the GeneratorForAnnotation optimization to skip files with well known
-  annotation names such as `override`, `Deprecated`, and `pragma`.
 
 ## 2.0.0
 

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 3.0.0-dev
+version: 3.0.0-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -889,7 +889,11 @@ foo generated content
     ''',
       testLibPartContent: '''
     part of 'test_lib.dart';
-    @deprecated
+
+    // Use this to avoid the short circuit.
+    const deprecated2 = deprecated;
+
+    @deprecated2
     int x;
     ''',
     );

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -99,32 +99,37 @@ $dartFormatWidth
     }
   });
 
-  test(
-    'Does not resolve the library if there are no top level annotations',
-    () async {
-      final builder = LibraryBuilder(
-        _StubGenerator<Deprecated>('Deprecated', elementBehavior: (_) => null),
-      );
-      final input = AssetId('a', 'lib/a.dart');
-      final assets = {input: 'main() {}'};
+  test('Does not resolve the library if there are no interesting top level '
+      'annotations', () async {
+    final builder = LibraryBuilder(
+      _StubGenerator<Deprecated>('Deprecated', elementBehavior: (_) => null),
+    );
+    final input = AssetId('a', 'lib/a.dart');
+    final assets = {
+      input: '''
+@Deprecated()
+@deprecated
+@override
+@pragma('')
+main() {}''',
+    };
 
-      final readerWriter =
-          TestReaderWriter()..testing.writeString(input, assets[input]!);
+    final readerWriter =
+        TestReaderWriter()..testing.writeString(input, assets[input]!);
 
-      final resolver = _TestingResolver(assets);
+    final resolver = _TestingResolver(assets);
 
-      await runBuilder(
-        builder,
-        [input],
-        readerWriter,
-        readerWriter,
-        _FixedResolvers(resolver),
-      );
+    await runBuilder(
+      builder,
+      [input],
+      readerWriter,
+      readerWriter,
+      _FixedResolvers(resolver),
+    );
 
-      expect(resolver.parsedUnits, {input});
-      expect(resolver.resolvedLibs, isEmpty);
-    },
-  );
+    expect(resolver.parsedUnits, {input});
+    expect(resolver.resolvedLibs, isEmpty);
+  });
 
   test('applies to annotated libraries', () async {
     final builder = LibraryBuilder(

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -294,13 +294,16 @@ class _StubGenerator<T> extends GeneratorForAnnotation<T> {
 
 const _inputMap = {
   'a|lib/file.dart': '''
-     @deprecated
+     // Use this to avoid the short circuit.
+     const deprecated2 = deprecated;
+
+     @deprecated2
      final foo = 'foo';
 
-     @deprecated
+     @deprecated2
      final bar = 'bar';
 
-     @deprecated
+     @deprecated2
      final baz = 'baz';
      ''',
 };


### PR DESCRIPTION
Previously we would bail out early for files with no top level annotations, this also skips well known annotations (although it isn't perfect, and assumes people aren't shadowing these names).