### PR TITLE
Bring up to analyzer 8.1.1, get rid of deprecated classes and methods.

### DIFF
--- a/example/lib/src/multiplier_generator.dart
+++ b/example/lib/src/multiplier_generator.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -13,13 +11,13 @@ import '../annotations.dart';
 class MultiplierGenerator extends GeneratorForAnnotation<Multiplier> {
   @override
   String generateForAnnotatedElement(
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) {
     final numValue = annotation.read('value').literalValue as num;
 
-    return 'num ${element.name3}Multiplied() => ${element.name3} * $numValue;';
+    return 'num ${element.name}Multiplied() => ${element.name} * $numValue;';
   }
 
   // Override this method to respond to annotations on directives: `import`,

--- a/example/lib/src/property_product_generator.dart
+++ b/example/lib/src/property_product_generator.dart
@@ -12,8 +12,7 @@ class PropertyProductGenerator extends Generator {
   String generate(LibraryReader library, BuildStep buildStep) {
     final productNames = topLevelNumVariables(
       library,
-      // ignore: deprecated_member_use until analyzer 7 support is dropped.
-    ).map((element) => element.name3).join(' * ');
+    ).map((element) => element.name).join(' * ');
 
     return '''
 num allProduct() => $productNames;

--- a/example/lib/src/property_sum_generator.dart
+++ b/example/lib/src/property_sum_generator.dart
@@ -12,8 +12,7 @@ class PropertySumGenerator extends Generator {
   String generate(LibraryReader library, BuildStep buildStep) {
     final sumNames = topLevelNumVariables(
       library,
-      // ignore: deprecated_member_use until analyzer 7 support is dropped.
-    ).map((element) => element.name3).join(' + ');
+    ).map((element) => element.name).join(' + ');
 
     return '''
 num allSum() => $sumNames;

--- a/example/lib/src/utils.dart
+++ b/example/lib/src/utils.dart
@@ -2,15 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:source_gen/source_gen.dart';
 
-/// Returns all [TopLevelVariableElement2] members in [reader]'s library that
+/// Returns all [TopLevelVariableElement] members in [reader]'s library that
 /// have a type of [num].
-Iterable<TopLevelVariableElement2> topLevelNumVariables(LibraryReader reader) =>
-    reader.allElements.whereType<TopLevelVariableElement2>().where(
+Iterable<TopLevelVariableElement> topLevelNumVariables(LibraryReader reader) =>
+    reader.allElements.whereType<TopLevelVariableElement>().where(
       (element) =>
           element.type.isDartCoreNum ||
           element.type.isDartCoreInt ||

--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -5,8 +5,7 @@
 import 'dart:convert';
 
 import 'package:analyzer/dart/ast/ast.dart';
-// ignore: deprecated_member_use until analyzer 7 support is dropped.
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -110,8 +109,7 @@ class _Builder extends Builder {
   }
 
   Future<void> _generateForLibrary(
-    // ignore: deprecated_member_use until analyzer 7 support is dropped.
-    LibraryElement2 library,
+    LibraryElement library,
     BuildStep buildStep,
   ) async {
     final generatedOutputs =
@@ -357,8 +355,7 @@ class LibraryBuilder extends _Builder {
 }
 
 Stream<GeneratedOutput> _generate(
-  // ignore: deprecated_member_use until analyzer 7 support is dropped.
-  LibraryElement2 library,
+  LibraryElement library,
   List<Generator> generators,
   BuildStep buildStep,
 ) async* {
@@ -443,8 +440,7 @@ const partIdRegExpLiteral = r'[A-Za-z_\d-]+';
 
 final _partIdRegExp = RegExp('^$partIdRegExpLiteral\$');
 
-// ignore: deprecated_member_use until analyzer 7 support is dropped.
-String languageOverrideForLibrary(LibraryElement2 library) {
+String languageOverrideForLibrary(LibraryElement library) {
   final override = library.languageVersion.override;
   return override == null
       ? ''

--- a/source_gen/lib/src/constants/reader.dart
+++ b/source_gen/lib/src/constants/reader.dart
@@ -3,8 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/constant/value.dart';
-// ignore: deprecated_member_use until analyzer 7 support is dropped.
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../type_checker.dart';
@@ -269,8 +268,7 @@ class _DartObjectConstant extends ConstantReader {
   ConstantReader read(String field) {
     final reader = peek(field);
     if (reader == null) {
-      // ignore: deprecated_member_use until analyzer 7 support is dropped.
-      assertHasField(objectValue.type!.element3 as InterfaceElement2, field);
+      assertHasField(objectValue.type!.element as InterfaceElement, field);
       return const _NullConstant();
     }
     return reader;

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -8,9 +8,6 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/constant/value.dart' show DartObjectImpl;
-
 import '../utils.dart';
 
 /// Attempts to extract what source code could be used to represent [object].
@@ -79,7 +76,7 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
       }
     }
   }
-  final i = (object as DartObjectImpl).constructorInvocation;
+  final i = object.constructorInvocation;
   if (i != null) {
     url = Uri.parse(urlOfElement(i.constructor.enclosingElement));
     String newToEmpty(String string) => string == 'new' ? '' : string;

--- a/source_gen/lib/src/constants/utils.dart
+++ b/source_gen/lib/src/constants/utils.dart
@@ -2,31 +2,29 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 
 /// Throws a [FormatException] if [root] does not have a given field [name].
 ///
-/// Super types [InterfaceElement2.supertype] are also checked before throwing.
-void assertHasField(InterfaceElement2 root, String name) {
-  InterfaceElement2? element = root;
+/// Super types [InterfaceElement.supertype] are also checked before throwing.
+void assertHasField(InterfaceElement root, String name) {
+  InterfaceElement? element = root;
   while (element != null) {
-    final field = element.getField2(name);
+    final field = element.getField(name);
     if (field != null) {
       return;
     }
-    element = element.supertype?.element3;
+    element = element.supertype?.element;
   }
   final allFields = {
-    ...root.fields2,
-    for (var t in root.allSupertypes) ...t.element3.fields2,
+    ...root.fields,
+    for (var t in root.allSupertypes) ...t.element.fields,
   };
 
   throw FormatException(
-    'Class ${root.name3} does not have field "$name".',
-    'Fields: \n  - ${allFields.map((e) => e.name3).join('\n  - ')}',
+    'Class ${root.name} does not have field "$name".',
+    'Fields: \n  - ${allFields.map((e) => e.name).join('\n  - ')}',
   );
 }
 

--- a/source_gen/lib/src/generator.dart
+++ b/source_gen/lib/src/generator.dart
@@ -5,8 +5,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/ast/ast.dart';
-// ignore: deprecated_member_use until analyzer 7 support is dropped.
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:source_span/source_span.dart';
 
@@ -48,8 +47,7 @@ class InvalidGenerationSource implements Exception {
   final String todo;
 
   /// The `Element2` associated with this error, if any.
-  /// ignore: deprecated_member_use until analyzer 7 support is dropped.
-  final Element2? element;
+  final Element? element;
 
   /// The [ElementDirective] associated with this error, if any.
   final ElementDirective? elementDirective;

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -4,8 +4,7 @@
 
 import 'dart:async';
 
-// ignore: deprecated_member_use until analyzer 7 support is dropped.
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 
 import 'constants/reader.dart';
@@ -68,9 +67,7 @@ abstract class GeneratorForAnnotation<T> extends Generator {
     this.inSdk,
   });
 
-  // This will switch to `typeNamed` in 4.0.0.
-  // ignore: deprecated_member_use_from_same_package
-  TypeChecker get typeChecker => TypeChecker.fromRuntime(T);
+  TypeChecker get typeChecker => TypeChecker.typeNamed(T);
 
   @override
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {
@@ -127,8 +124,7 @@ abstract class GeneratorForAnnotation<T> extends Generator {
   /// Implementations should return `null` when no content is generated. Empty
   /// or whitespace-only [String] instances are also ignored.
   dynamic generateForAnnotatedElement(
-    // ignore: deprecated_member_use until analyzer 7 support is dropped.
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) {}

--- a/source_gen/lib/src/library.dart
+++ b/source_gen/lib/src/library.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:path/path.dart' as p;
 
@@ -19,34 +17,34 @@ class AnnotatedDirective {
 
   const AnnotatedDirective(this.annotation, this.directive);
 
-  Metadata? get metadata2 => directive.metadata2;
+  Metadata? get metadata2 => directive.metadata;
 }
 
 /// Result of finding an [annotation] on [element] through [LibraryReader].
 class AnnotatedElement {
   final ConstantReader annotation;
-  final Element2 element;
+  final Element element;
 
   const AnnotatedElement(this.annotation, this.element);
 }
 
-/// A high-level wrapper API with common functionality for [LibraryElement2].
+/// A high-level wrapper API with common functionality for [LibraryElement].
 class LibraryReader {
-  final LibraryElement2 element;
+  final LibraryElement element;
 
   LibraryReader(this.element);
 
-  /// Returns a top-level [ClassElement2] publicly visible in by [name].
+  /// Returns a top-level [ClassElement] publicly visible in by [name].
   ///
-  /// Unlike [LibraryElement2.getClass2], this also correctly traverses
+  /// Unlike [LibraryElement.getClass], this also correctly traverses
   /// identifiers that are accessible via one or more `export` directives.
-  ClassElement2? findType(String name) {
+  ClassElement? findType(String name) {
     final type = element.exportNamespace.get2(name);
-    return type is ClassElement2 ? type : null;
+    return type is ClassElement ? type : null;
   }
 
   /// All of the declarations in this library.
-  Iterable<Element2> get allElements => [element, ...element.children2];
+  Iterable<Element> get allElements => [element, ...element.children];
 
   /// All of the declarations in this library annotated with [checker].
   Iterable<AnnotatedElement> annotatedWith(
@@ -71,8 +69,8 @@ class LibraryReader {
   }) sync* {
     final firstFragment = element.firstFragment;
     final directives = [
-      ...firstFragment.libraryImports2,
-      ...firstFragment.libraryExports2,
+      ...firstFragment.libraryImports,
+      ...firstFragment.libraryExports,
       ...firstFragment.partIncludes,
     ];
 
@@ -114,7 +112,7 @@ class LibraryReader {
   ///
   /// This is a typed convenience function for using [pathToUrl], and the same
   /// API restrictions hold around supported schemes and relative paths.
-  Uri pathToElement(Element2 element) => pathToUrl(element.library2!.uri);
+  Uri pathToElement(Element element) => pathToUrl(element.library!.uri);
 
   /// Returns a [Uri] from the current library to the one provided.
   ///
@@ -190,8 +188,8 @@ class LibraryReader {
   }
 
   /// All of the elements representing classes in this library.
-  Iterable<ClassElement2> get classes => element.classes;
+  Iterable<ClassElement> get classes => element.classes;
 
   /// All of the elements representing enums in this library.
-  Iterable<EnumElement2> get enums => element.enums;
+  Iterable<EnumElement> get enums => element.enums;
 }

--- a/source_gen/lib/src/span_for_element.dart
+++ b/source_gen/lib/src/span_for_element.dart
@@ -2,10 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:source_span/source_span.dart';
 
 import 'utils.dart';
@@ -21,38 +19,38 @@ import 'utils.dart';
 ///
 /// Not all results from the analyzer API may return source information as part
 /// of the element, so [file] may need to be manually provided in those cases.
-SourceSpan spanForElement(Element2 element, [SourceFile? file]) {
+SourceSpan spanForElement(Element element, [SourceFile? file]) {
   final fragment = element.firstFragment;
   final url = assetToPackageUrl(fragment.libraryFragment!.source.uri);
   if (file == null) {
     final contents = fragment.libraryFragment?.source.contents;
     if (contents == null) {
       return SourceSpan(
-        SourceLocation(fragment.nameOffset2!, sourceUrl: url),
+        SourceLocation(fragment.nameOffset!, sourceUrl: url),
         SourceLocation(
-          fragment.nameOffset2! + fragment.name2!.length,
+          fragment.nameOffset! + fragment.name!.length,
           sourceUrl: url,
         ),
-        fragment.name2!,
+        fragment.name!,
       );
     }
     file = SourceFile.fromString(contents.data, url: url);
   }
-  if (fragment.nameOffset2 == null) {
-    if (element is PropertyInducingElement2) {
-      if (element.getter2 != null) {
-        return spanForElement(element.getter2!);
+  if (fragment.nameOffset == null) {
+    if (element is PropertyInducingElement) {
+      if (element.getter != null) {
+        return spanForElement(element.getter!);
       }
 
-      if (element.setter2 != null) {
-        return spanForElement(element.setter2!);
+      if (element.setter != null) {
+        return spanForElement(element.setter!);
       }
     }
   }
 
   return file.span(
-    fragment.nameOffset2!,
-    fragment.nameOffset2! + fragment.name2!.length,
+    fragment.nameOffset!,
+    fragment.nameOffset! + fragment.name!.length,
   );
 }
 

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -2,14 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'dart:mirrors' hide SourceLocation;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:source_span/source_span.dart';
@@ -86,12 +84,6 @@ If you need an exact match, use `fromUrl`.''')
     Object element, {
     bool throwOnUnresolved = true,
   }) {
-    if (element case final Annotatable annotatable) {
-      final annotations = annotatable.metadata2.annotations;
-      if (annotations.isEmpty) {
-        return null;
-      }
-    }
     final results = annotationsOf(
       element,
       throwOnUnresolved: throwOnUnresolved,
@@ -102,7 +94,7 @@ If you need an exact match, use `fromUrl`.''')
   /// Returns if a constant annotating [element] is assignable to this type.
   ///
   /// Throws on unresolved annotations unless [throwOnUnresolved] is `false`.
-  bool hasAnnotationOf(Element2 element, {bool throwOnUnresolved = true}) =>
+  bool hasAnnotationOf(Element element, {bool throwOnUnresolved = true}) =>
       firstAnnotationOf(element, throwOnUnresolved: throwOnUnresolved) != null;
 
   /// Returns the first constant annotating [element] that is exactly this type.
@@ -110,31 +102,24 @@ If you need an exact match, use `fromUrl`.''')
   /// Throws [UnresolvedAnnotationException] on unresolved annotations unless
   /// [throwOnUnresolved] is explicitly set to `false` (default is `true`).
   DartObject? firstAnnotationOfExact(
-    Element2 element, {
+    Element element, {
     bool throwOnUnresolved = true,
   }) {
-    if (element case final Annotatable annotatable) {
-      final annotations = annotatable.metadata2.annotations;
-      if (annotations.isEmpty) {
-        return null;
-      }
-      final results = annotationsOfExact(
-        element,
-        throwOnUnresolved: throwOnUnresolved,
-      );
-      return results.isEmpty ? null : results.first;
+    if (element.metadata.annotations.isEmpty) {
+      return null;
     }
-    return null;
+    final results = annotationsOfExact(
+      element,
+      throwOnUnresolved: throwOnUnresolved,
+    );
+    return results.isEmpty ? null : results.first;
   }
 
   /// Returns if a constant annotating [element] is exactly this type.
   ///
   /// Throws [UnresolvedAnnotationException] on unresolved annotations unless
   /// [throwOnUnresolved] is explicitly set to `false` (default is `true`).
-  bool hasAnnotationOfExact(
-    Element2 element, {
-    bool throwOnUnresolved = true,
-  }) =>
+  bool hasAnnotationOfExact(Element element, {bool throwOnUnresolved = true}) =>
       firstAnnotationOfExact(element, throwOnUnresolved: throwOnUnresolved) !=
       null;
 
@@ -145,7 +130,7 @@ If you need an exact match, use `fromUrl`.''')
     bool throwOnUnresolved = true,
   }) {
     final result = annotation.computeConstantValue();
-    if (result == null && throwOnUnresolved && element is Element2) {
+    if (result == null && throwOnUnresolved && element is Element) {
       throw UnresolvedAnnotationException._from(element, annotationIndex);
     }
     return result;
@@ -169,8 +154,9 @@ If you need an exact match, use `fromUrl`.''')
     bool Function(DartType) predicate, {
     bool throwOnUnresolved = true,
   }) sync* {
-    if (element case final Annotatable annotatable) {
-      final annotations = annotatable.metadata2.annotations;
+    if (element
+        case Element(:final metadata) || ElementDirective(:final metadata)) {
+      final annotations = metadata.annotations;
       for (var i = 0; i < annotations.length; i++) {
         final value = _computeConstantValue(
           element,
@@ -190,7 +176,7 @@ If you need an exact match, use `fromUrl`.''')
   /// Throws [UnresolvedAnnotationException] on unresolved annotations unless
   /// [throwOnUnresolved] is explicitly set to `false` (default is `true`).
   Iterable<DartObject> annotationsOfExact(
-    Element2 element, {
+    Element element, {
     bool throwOnUnresolved = true,
   }) => _annotationsWhere(
     element,
@@ -199,26 +185,25 @@ If you need an exact match, use `fromUrl`.''')
   );
 
   /// Returns `true` if the type of [element] can be assigned to this type.
-  bool isAssignableFrom(Element2 element) =>
+  bool isAssignableFrom(Element element) =>
       isExactly(element) ||
-      (element is InterfaceElement2 &&
-          element.allSupertypes.any(isExactlyType));
+      (element is InterfaceElement && element.allSupertypes.any(isExactlyType));
 
   /// Returns `true` if [staticType] can be assigned to this type.
   bool isAssignableFromType(DartType staticType) {
-    final element = staticType.element3;
+    final element = staticType.element;
     return element != null && isAssignableFrom(element);
   }
 
   /// Returns `true` if representing the exact same class as [element].
-  bool isExactly(Element2 element);
+  bool isExactly(Element element);
 
   /// Returns `true` if representing the exact same type as [staticType].
   ///
-  /// This will always return false for types without a backingclass such as
+  /// This will always return false for types without a backing class such as
   /// `void` or function types.
   bool isExactlyType(DartType staticType) {
-    final element = staticType.element3;
+    final element = staticType.element;
     if (element != null) {
       return isExactly(element);
     } else {
@@ -230,8 +215,8 @@ If you need an exact match, use `fromUrl`.''')
   ///
   /// This check only takes into account the *extends* hierarchy. If you wish
   /// to check mixins and interfaces, use [isAssignableFrom].
-  bool isSuperOf(Element2 element) {
-    if (element is InterfaceElement2) {
+  bool isSuperOf(Element element) {
+    if (element is InterfaceElement) {
       var theSuper = element.supertype;
 
       do {
@@ -250,7 +235,7 @@ If you need an exact match, use `fromUrl`.''')
   ///
   /// This only takes into account the *extends* hierarchy. If you wish
   /// to check mixins and interfaces, use [isAssignableFromType].
-  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element3!);
+  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element!);
 }
 
 // Checks a static type against another static type;
@@ -260,11 +245,11 @@ class _LibraryTypeChecker extends TypeChecker {
   const _LibraryTypeChecker(this._type) : super._();
 
   @override
-  bool isExactly(Element2 element) =>
-      element is InterfaceElement2 && element == _type.element3;
+  bool isExactly(Element element) =>
+      element is InterfaceElement && element == _type.element;
 
   @override
-  String toString() => urlOfElement(_type.element3!);
+  String toString() => urlOfElement(_type.element!);
 }
 
 // Checks a runtime type against a static type.
@@ -284,7 +269,7 @@ class _MirrorTypeChecker extends TypeChecker {
       _cache[this] ??= TypeChecker.fromUrl(_uriOf(reflectClass(_type)));
 
   @override
-  bool isExactly(Element2 element) => _computed.isExactly(element);
+  bool isExactly(Element element) => _computed.isExactly(element);
 
   @override
   String toString() => _computed.toString();
@@ -310,9 +295,9 @@ class _NameTypeChecker extends TypeChecker {
   }
 
   @override
-  bool isExactly(Element2 element) {
-    final uri = element.library2!.uri;
-    return element.name3 == _typeName &&
+  bool isExactly(Element element) {
+    final uri = element.library!.uri;
+    return element.name == _typeName &&
         (_inPackage == null ||
             (((uri.scheme == 'dart') == _inSdk) &&
                 uri.pathSegments.first == _inPackage));
@@ -346,7 +331,7 @@ class _UriTypeChecker extends TypeChecker {
       (url is String ? url : normalizeUrl(url as Uri).toString());
 
   @override
-  bool isExactly(Element2 element) => hasSameUrl(urlOfElement(element));
+  bool isExactly(Element element) => hasSameUrl(urlOfElement(element));
 
   @override
   String toString() => '$uri';
@@ -358,8 +343,7 @@ class _AnyChecker extends TypeChecker {
   const _AnyChecker(this._checkers) : super._();
 
   @override
-  bool isExactly(Element2 element) =>
-      _checkers.any((c) => c.isExactly(element));
+  bool isExactly(Element element) => _checkers.any((c) => c.isExactly(element));
 }
 
 /// Exception thrown when [TypeChecker] fails to resolve a metadata annotation.
@@ -370,18 +354,18 @@ class _AnyChecker extends TypeChecker {
 /// defined (for build systems such as Bazel).
 class UnresolvedAnnotationException implements Exception {
   /// Element that was annotated with something we could not resolve.
-  final Element2 annotatedElement;
+  final Element annotatedElement;
 
   /// Source span of the annotation that was not resolved.
   ///
   /// May be `null` if the import library was not found.
   final SourceSpan? annotationSource;
 
-  static SourceSpan? _findSpan(Element2 annotatedElement, int annotationIndex) {
+  static SourceSpan? _findSpan(Element annotatedElement, int annotationIndex) {
     try {
       final parsedLibrary =
-          annotatedElement.session!.getParsedLibraryByElement2(
-                annotatedElement.library2!,
+          annotatedElement.session!.getParsedLibraryByElement(
+                annotatedElement.library!,
               )
               as ParsedLibraryResult;
       final declaration = parsedLibrary.getFragmentDeclaration(
@@ -430,7 +414,7 @@ the version of `package:source_gen`, `package:analyzer` from `pubspec.lock`.
   /// Creates an exception from an annotation ([annotationIndex]) that was not
   /// resolvable while traversing `metadata2` on [annotatedElement].
   factory UnresolvedAnnotationException._from(
-    Element2 annotatedElement,
+    Element annotatedElement,
     int annotationIndex,
   ) {
     final sourceSpan = _findSpan(annotatedElement, annotationIndex);

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';

--- a/source_gen/lib/src/utils.dart
+++ b/source_gen/lib/src/utils.dart
@@ -4,10 +4,8 @@
 
 import 'dart:io';
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:path/path.dart' as p;
@@ -22,20 +20,20 @@ import 'package:yaml/yaml.dart';
 /// typedef VoidFunc = void Function();
 /// ```
 ///
-/// This function will return `'VoidFunc'`, unlike [DartType.element3]`.name3`.
+/// This function will return `'VoidFunc'`, unlike [DartType.element]`.name`.
 String typeNameOf(DartType type) {
-  final aliasElement = type.alias?.element2;
+  final aliasElement = type.alias?.element;
   if (aliasElement != null) {
-    return aliasElement.name3!;
+    return aliasElement.name!;
   }
   if (type is DynamicType) {
     return 'dynamic';
   }
   if (type is InterfaceType) {
-    return type.element3.name3!;
+    return type.element.name!;
   }
   if (type is TypeParameterType) {
-    return type.element3.name3!;
+    return type.element.name!;
   }
   throw UnimplementedError('(${type.runtimeType}) $type');
 }
@@ -46,7 +44,7 @@ bool hasExpectedPartDirective(CompilationUnit unit, String part) => unit
     .any((e) => e.uri.stringValue == part);
 
 /// Returns a uri suitable for `part of "..."` when pointing to [element].
-String uriOfPartial(LibraryElement2 element, AssetId source, AssetId output) {
+String uriOfPartial(LibraryElement element, AssetId source, AssetId output) {
   assert(source.package == output.package);
   return p.url.relative(source.path, from: p.url.dirname(output.path));
 }
@@ -59,13 +57,13 @@ String computePartUrl(AssetId input, AssetId output) => p.url.joinAll(
 );
 
 /// Returns a URL representing [element].
-String urlOfElement(Element2 element) =>
+String urlOfElement(Element element) =>
     element.kind == ElementKind.DYNAMIC
         ? 'dart:core#dynamic'
         // using librarySource.uri – in case the element is in a part
         : normalizeUrl(
-          element.library2!.uri,
-        ).replace(fragment: element.name3).toString();
+          element.library!.uri,
+        ).replace(fragment: element.name).toString();
 
 Uri normalizeUrl(Uri url) => switch (url.scheme) {
   'dart' => normalizeDartUrl(url),

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=7.4.0 <9.0.0'
+  analyzer: '>=8.1.1 <9.0.0'
   async: ^2.10.0
   build: ^3.0.0
   dart_style: ^3.0.0

--- a/source_gen/test/constants/utils_test.dart
+++ b/source_gen/test/constants/utils_test.dart
@@ -2,17 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/src/constants/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('assertHasField', () {
-    late LibraryElement2 testLib;
+    late LibraryElement testLib;
 
     setUpAll(() async {
       testLib = await resolveSource(
@@ -36,17 +34,17 @@ void main() {
     });
 
     test('should not throw when a class contains a field', () {
-      final $A = testLib.getClass2('A')!;
+      final $A = testLib.getClass('A')!;
       expect(() => assertHasField($A, 'a'), returnsNormally);
     });
 
     test('should not throw when a super class contains a field', () {
-      final $B = testLib.getClass2('B')!;
+      final $B = testLib.getClass('B')!;
       expect(() => assertHasField($B, 'a'), returnsNormally);
     });
 
     test('should throw when a class does not contain a field', () {
-      final $C = testLib.getClass2('C')!;
+      final $C = testLib.getClass('C')!;
       expect(() => assertHasField($C, 'a'), throwsFormatException);
     });
   });
@@ -86,8 +84,8 @@ void main() {
       );
       objects =
           testLib
-              .getClass2('Example')!
-              .metadata2
+              .getClass('Example')!
+              .metadata
               .annotations
               .map((e) => e.computeConstantValue()!)
               .toList();

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/source_gen.dart';
@@ -61,8 +59,8 @@ void main() {
       ''', (resolver) async => (await resolver.findLibraryByName('test_lib'))!);
       constants =
           library
-              .getClass2('Example')!
-              .metadata2
+              .getClass('Example')!
+              .metadata
               .annotations
               .map((e) => ConstantReader(e.computeConstantValue()!))
               .toList();
@@ -157,7 +155,7 @@ void main() {
 
     test('should read a Type', () {
       expect(constants[11].isType, isTrue);
-      expect(constants[11].typeValue.element3!.name3, 'DateTime');
+      expect(constants[11].typeValue.element!.name, 'DateTime');
       expect(constants[11].isLiteral, isFalse);
       expect(() => constants[11].literalValue, throwsFormatException);
     });
@@ -304,8 +302,8 @@ void main() {
       ''', (resolver) async => (await resolver.findLibraryByName('test_lib'))!);
       constants =
           library
-              .getClass2('Example')!
-              .metadata2
+              .getClass('Example')!
+              .metadata
               .annotations
               .map((e) => ConstantReader(e.computeConstantValue()))
               .toList();

--- a/source_gen/test/external_only_type_checker_test.dart
+++ b/source_gen/test/external_only_type_checker_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 // The tests in this file are only ran externally, as the behavior only works
 // externally. Internally this test is skipped.
 
@@ -58,7 +56,7 @@ void main() {
         expect(
           checkNonPublic().isExactlyType(staticNonPublic),
           isTrue,
-          reason: '${checkNonPublic()} != ${staticNonPublic.element3.name3}',
+          reason: '${checkNonPublic()} != ${staticNonPublic.element.name}',
         );
       });
 
@@ -68,7 +66,7 @@ void main() {
           isTrue,
           reason:
               '${checkNonPublic()} is not assignable from '
-              '${staticNonPublic.element3.name3}',
+              '${staticNonPublic.element.name}',
         );
       });
     });

--- a/source_gen/test/generator_for_annotation_test.dart
+++ b/source_gen/test/generator_for_annotation_test.dart
@@ -6,11 +6,9 @@
 @Timeout.factor(3)
 library;
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/source_gen.dart';
@@ -43,7 +41,7 @@ void main() {
       'Repeating',
       elementBehavior: (element) sync* {
         yield '// There are deprecated values in this library!';
-        yield '// ${element.name3}';
+        yield '// ${element.name}';
       },
     );
     final builder = LibraryBuilder(generator);
@@ -172,7 +170,6 @@ $dartFormatWidth
               LibraryImport() => '// LibraryImport',
               LibraryExport() => '// LibraryExport',
               PartInclude() => '// PartInclude',
-              // ignore: unreachable_switch_case on analyzer 7, needed on 8.
               ElementDirective() => '// ElementDirective',
             },
         elementBehavior: (element) => '// ${element.runtimeType}',
@@ -267,7 +264,7 @@ $dartFormatWidth
 class _StubGenerator<T> extends GeneratorForAnnotation<T> {
   final String _name;
   final Object? Function(ElementDirective) directiveBehavior;
-  final Object? Function(Element2) elementBehavior;
+  final Object? Function(Element) elementBehavior;
 
   const _StubGenerator(
     this._name, {
@@ -285,7 +282,7 @@ class _StubGenerator<T> extends GeneratorForAnnotation<T> {
 
   @override
   Object? generateForAnnotatedElement(
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) => elementBehavior(element);
@@ -335,7 +332,7 @@ class _TestingResolver implements ReleasableResolver {
   }
 
   @override
-  Future<LibraryElement2> libraryFor(
+  Future<LibraryElement> libraryFor(
     AssetId assetId, {
     bool allowSyntaxErrors = false,
   }) async {

--- a/source_gen/test/library/find_type_test.dart
+++ b/source_gen/test/library/find_type_test.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/source_gen.dart';
@@ -46,11 +44,11 @@ void main() {
   });
 
   test('class count', () {
-    expect(library.classes.map((c) => c.name3), ['Example', 'PartClass']);
+    expect(library.classes.map((c) => c.name), ['Example', 'PartClass']);
   });
 
   test('enum count', () {
-    expect(library.enums.map((e) => e.name3), ['Enum', 'PartEnum']);
+    expect(library.enums.map((e) => e.name), ['Enum', 'PartEnum']);
   });
 
   test('should return a type not exported', () {
@@ -74,4 +72,4 @@ void main() {
   });
 }
 
-const _isClassElement = TypeMatcher<ClassElement2>();
+const _isClassElement = TypeMatcher<ClassElement>();

--- a/source_gen/test/library/path_to_url_test.dart
+++ b/source_gen/test/library/path_to_url_test.dart
@@ -2,10 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 // Increase timeouts on this test which resolves source code and can be slow.
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
@@ -159,7 +157,7 @@ void main() {
   });
 }
 
-class _FakeLibraryElement implements LibraryElement2 {
+class _FakeLibraryElement implements LibraryElement {
   final Uri _uri;
 
   _FakeLibraryElement(this._uri);

--- a/source_gen/test/span_for_element_test.dart
+++ b/source_gen/test/span_for_element_test.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/src/span_for_element.dart';
@@ -13,7 +11,7 @@ import 'package:test/test.dart';
 
 void main() {
   glyph.ascii = true;
-  late LibraryElement2 library;
+  late LibraryElement library;
   late Resolver resolver;
 
   setUpAll(() async {
@@ -41,7 +39,7 @@ abstract class Example implements List {
 
   test('should highlight the use of "class Example"', () async {
     expect(
-      spanForElement(library.getClass2('Example')!).message('Here it is'),
+      spanForElement(library.getClass('Example')!).message('Here it is'),
       r"""
 line 3, column 16 of package:test_lib/test_lib.dart: Here it is
   ,
@@ -54,7 +52,7 @@ line 3, column 16 of package:test_lib/test_lib.dart: Here it is
   test('should correctly highlight getter', () async {
     expect(
       spanForElement(
-        library.getClass2('Example')!.getField2('getter')!,
+        library.getClass('Example')!.getField('getter')!,
       ).message('Here it is'),
       r"""
 line 4, column 15 of package:test_lib/test_lib.dart: Here it is
@@ -68,7 +66,7 @@ line 4, column 15 of package:test_lib/test_lib.dart: Here it is
   test('should correctly highlight setter', () async {
     expect(
       spanForElement(
-        library.getClass2('Example')!.getField2('setter')!,
+        library.getClass('Example')!.getField('setter')!,
       ).message('Here it is'),
       r"""
 line 5, column 7 of package:test_lib/test_lib.dart: Here it is
@@ -82,7 +80,7 @@ line 5, column 7 of package:test_lib/test_lib.dart: Here it is
   test('should correctly highlight field', () async {
     expect(
       spanForElement(
-        library.getClass2('Example')!.getField2('field')!,
+        library.getClass('Example')!.getField('field')!,
       ).message('Here it is'),
       r"""
 line 6, column 7 of package:test_lib/test_lib.dart: Here it is
@@ -96,7 +94,7 @@ line 6, column 7 of package:test_lib/test_lib.dart: Here it is
   test('highlight getter with getter/setter property', () async {
     expect(
       spanForElement(
-        library.getClass2('Example')!.getField2('fieldProp')!,
+        library.getClass('Example')!.getField('fieldProp')!,
       ).message('Here it is'),
       r"""
 line 7, column 11 of package:test_lib/test_lib.dart: Here it is
@@ -109,7 +107,7 @@ line 7, column 11 of package:test_lib/test_lib.dart: Here it is
 
   test('highlights based on AstNode source location', () async {
     final element =
-        library.getClass2('Example')!.getField2('field')!.firstFragment;
+        library.getClass('Example')!.getField('field')!.firstFragment;
     final node = (await resolver.astNodeFor(element, resolve: true))!;
     expect(spanForNode(node).message('Here it is'), r"""
 line 6, column 7 of package:test_lib/test_lib.dart: Here it is

--- a/source_gen/test/src/comment_generator.dart
+++ b/source_gen/test/src/comment_generator.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:source_gen/source_gen.dart';
 
 /// Generates a single-line comment for each class
@@ -17,7 +15,7 @@ class CommentGenerator extends Generator {
   Future<String> generate(LibraryReader library, _) async {
     final output = <String>[];
     if (forLibrary) {
-      var name = library.element.name3!;
+      var name = library.element.name!;
       if (name.isEmpty) {
         name = library.element.uri.pathSegments.last;
       }
@@ -46,7 +44,7 @@ class CommentGenerator extends Generator {
             // No directive relates to the class, just throw with the first
             // export.
             elementDirective:
-                classElement.library2.firstFragment.libraryExports2.first,
+                classElement.library.firstFragment.libraryExports.first,
           );
         }
         output.add('// Code for "$classElement"');
@@ -60,6 +58,6 @@ class CommentGenerator extends Generator {
 class DeprecatedGeneratorForAnnotation
     extends GeneratorForAnnotation<Deprecated> {
   @override
-  String generateForAnnotatedElement(Element2 element, _, _) =>
+  String generateForAnnotatedElement(Element element, _, _) =>
       '// "$element" is deprecated!';
 }

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -3,15 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: unreachable_from_main
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 // Increase timeouts on this test which resolves source code and can be slow.
 @Timeout.factor(2.0)
 library;
 
 import 'dart:collection';
 
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
@@ -32,7 +30,7 @@ void main() {
   late TypeChecker staticMapMixinChecker;
   late TypeChecker staticHashMapChecker;
   late TypeChecker staticEnumChecker;
-  late LibraryElement2 core;
+  late LibraryElement core;
 
   // Resolved top-level types from package:source_gen.
   late InterfaceType staticGenerator;
@@ -47,9 +45,9 @@ void main() {
   late InterfaceType staticMyEnumWithMixin;
 
   setUpAll(() async {
-    late LibraryElement2 collection;
+    late LibraryElement collection;
     late LibraryReader sourceGen;
-    late LibraryElement2 testSource;
+    late LibraryElement testSource;
     await resolveSources(
       {
         'source_gen|test/example.dart': r'''
@@ -77,20 +75,20 @@ void main() {
     );
 
     final staticIterable = core
-        .getClass2('Iterable')!
+        .getClass('Iterable')!
         .instantiate(
           typeArguments: [core.typeProvider.dynamicType],
           nullabilitySuffix: NullabilitySuffix.none,
         );
     staticIterableChecker = TypeChecker.fromStatic(staticIterable);
     staticUri = core
-        .getClass2('Uri')!
+        .getClass('Uri')!
         .instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         );
     staticMap = core
-        .getClass2('Map')!
+        .getClass('Map')!
         .instantiate(
           typeArguments: [
             core.typeProvider.dynamicType,
@@ -100,41 +98,41 @@ void main() {
         );
     staticMapChecker = TypeChecker.fromStatic(staticMap);
     staticEnum = core
-        .getClass2('Enum')!
+        .getClass('Enum')!
         .instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         );
     staticEnumChecker = TypeChecker.fromStatic(staticEnum);
     staticEnumMixin = (testSource.exportNamespace.get2('MyEnumMixin')!
-            as InterfaceElement2)
+            as InterfaceElement)
         .instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         );
     staticEnumMixinChecker = TypeChecker.fromStatic(staticEnumMixin);
     staticMapMixin = (testSource.exportNamespace.get2('MyMapMixin')!
-            as InterfaceElement2)
+            as InterfaceElement)
         .instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         );
     staticMapMixinChecker = TypeChecker.fromStatic(staticMapMixin);
     staticMyEnum = (testSource.exportNamespace.get2('MyEnum')!
-            as InterfaceElement2)
+            as InterfaceElement)
         .instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         );
     staticMyEnumWithMixin = (testSource.exportNamespace.get2('MyEnumWithMixin')!
-            as InterfaceElement2)
+            as InterfaceElement)
         .instantiate(
           typeArguments: [],
           nullabilitySuffix: NullabilitySuffix.none,
         );
 
     staticHashMap = collection
-        .getClass2('HashMap')!
+        .getClass('HashMap')!
         .instantiate(
           typeArguments: [
             core.typeProvider.dynamicType,
@@ -144,7 +142,7 @@ void main() {
         );
     staticHashMapChecker = TypeChecker.fromStatic(staticHashMap);
     staticUnmodifiableListView = collection
-        .getClass2('UnmodifiableListView')!
+        .getClass('UnmodifiableListView')!
         .instantiate(
           typeArguments: [core.typeProvider.dynamicType],
           nullabilitySuffix: NullabilitySuffix.none,
@@ -223,7 +221,7 @@ void main() {
       () {
         test('should equal MapMixin class', () {
           expect(checkMapMixin().isExactlyType(staticMapMixin), isTrue);
-          expect(checkMapMixin().isExactly(staticMapMixin.element3), isTrue);
+          expect(checkMapMixin().isExactly(staticMapMixin.element), isTrue);
         });
       },
       onPlatform: const {
@@ -236,7 +234,7 @@ void main() {
         expect(
           checkMap().isExactlyType(staticMap),
           isTrue,
-          reason: '${checkMap()} != ${staticMap.element3.name3}',
+          reason: '${checkMap()} != ${staticMap.element.name}',
         );
       });
 
@@ -268,7 +266,7 @@ void main() {
       test('should be assignable from Map<String, String>', () {
         // Using Uri.queryParameters to get a Map<String, String>
         final stringStringMapType =
-            staticUri.getGetter2('queryParameters')!.returnType;
+            staticUri.getGetter('queryParameters')!.returnType;
 
         expect(checkMap().isAssignableFromType(stringStringMapType), isTrue);
         expect(checkMap().isExactlyType(stringStringMapType), isTrue);
@@ -298,7 +296,7 @@ void main() {
         expect(
           checkGenerator().isExactlyType(staticGenerator),
           isTrue,
-          reason: '${checkGenerator()} != ${staticGenerator.element3.name3}',
+          reason: '${checkGenerator()} != ${staticGenerator.element.name}',
         );
       });
 
@@ -308,7 +306,7 @@ void main() {
           isFalse,
           reason:
               '${checkGenerator()} is super of '
-              '${staticGenerator.element3.name3}',
+              '${staticGenerator.element.name}',
         );
       });
 
@@ -318,7 +316,7 @@ void main() {
           isTrue,
           reason:
               '${checkGenerator()} is not super of '
-              '${staticGeneratorForAnnotation.element3.name3}',
+              '${staticGeneratorForAnnotation.element.name}',
         );
       });
 
@@ -328,7 +326,7 @@ void main() {
           isTrue,
           reason:
               '${checkGenerator()} is not assignable from '
-              '${staticGeneratorForAnnotation.element3.name3}',
+              '${staticGeneratorForAnnotation.element.name}',
         );
       });
     });
@@ -336,23 +334,15 @@ void main() {
 
   group('TypeChecker.forRuntime', () {
     commonTests(
-      // ignore: deprecated_member_use_from_same_package
-      checkIterable: () => const TypeChecker.fromRuntime(Iterable),
-      // ignore: deprecated_member_use_from_same_package
-      checkEnum: () => const TypeChecker.fromRuntime(Enum),
-      // ignore: deprecated_member_use_from_same_package
-      checkEnumMixin: () => const TypeChecker.fromRuntime(MyEnumMixin),
-      // ignore: deprecated_member_use_from_same_package
-      checkMap: () => const TypeChecker.fromRuntime(Map),
-      // ignore: deprecated_member_use_from_same_package
-      checkMapMixin: () => const TypeChecker.fromRuntime(MyMapMixin),
-      // ignore: deprecated_member_use_from_same_package
-      checkHashMap: () => const TypeChecker.fromRuntime(HashMap),
-      // ignore: deprecated_member_use_from_same_package
-      checkGenerator: () => const TypeChecker.fromRuntime(Generator),
+      checkIterable: () => const TypeChecker.typeNamed(Iterable),
+      checkEnum: () => const TypeChecker.typeNamed(Enum),
+      checkEnumMixin: () => const TypeChecker.typeNamed(MyEnumMixin),
+      checkMap: () => const TypeChecker.typeNamed(Map),
+      checkMapMixin: () => const TypeChecker.typeNamed(MyMapMixin),
+      checkHashMap: () => const TypeChecker.typeNamed(HashMap),
+      checkGenerator: () => const TypeChecker.typeNamed(Generator),
 
       checkGeneratorForAnnotation:
-          // ignore: deprecated_member_use_from_same_packages
           () => const TypeChecker.typeNamed(
             GeneratorForAnnotation,
             inPackage: 'source_gen',
@@ -455,7 +445,7 @@ void main() {
       @depracated // Intentionally mispelled.
       class X {}
     ''', (resolver) async => (await resolver.findLibraryByName('_test'))!);
-    final classX = library.getClass2('X')!;
+    final classX = library.getClass('X')!;
     const $deprecated = TypeChecker.typeNamed(
       Deprecated,
       inPackage: 'core',
@@ -490,10 +480,10 @@ void main() {
     late TypeChecker $B;
     late TypeChecker $C;
 
-    late ClassElement2 $ExampleOfA;
-    late ClassElement2 $ExampleOfMultiA;
-    late ClassElement2 $ExampleOfAPlusB;
-    late ClassElement2 $ExampleOfBPlusC;
+    late ClassElement $ExampleOfA;
+    late ClassElement $ExampleOfMultiA;
+    late ClassElement $ExampleOfAPlusB;
+    late ClassElement $ExampleOfBPlusC;
 
     setUpAll(() async {
       final library = await resolveSource(r'''
@@ -529,7 +519,7 @@ void main() {
 
       $A = TypeChecker.fromStatic(
         library
-            .getClass2('A')!
+            .getClass('A')!
             .instantiate(
               typeArguments: [],
               nullabilitySuffix: NullabilitySuffix.none,
@@ -537,7 +527,7 @@ void main() {
       );
       $B = TypeChecker.fromStatic(
         library
-            .getClass2('B')!
+            .getClass('B')!
             .instantiate(
               typeArguments: [],
               nullabilitySuffix: NullabilitySuffix.none,
@@ -545,55 +535,55 @@ void main() {
       );
       $C = TypeChecker.fromStatic(
         library
-            .getClass2('C')!
+            .getClass('C')!
             .instantiate(
               typeArguments: [],
               nullabilitySuffix: NullabilitySuffix.none,
             ),
       );
-      $ExampleOfA = library.getClass2('ExampleOfA')!;
-      $ExampleOfMultiA = library.getClass2('ExampleOfMultiA')!;
-      $ExampleOfAPlusB = library.getClass2('ExampleOfAPlusB')!;
-      $ExampleOfBPlusC = library.getClass2('ExampleOfBPlusC')!;
+      $ExampleOfA = library.getClass('ExampleOfA')!;
+      $ExampleOfMultiA = library.getClass('ExampleOfMultiA')!;
+      $ExampleOfAPlusB = library.getClass('ExampleOfAPlusB')!;
+      $ExampleOfBPlusC = library.getClass('ExampleOfBPlusC')!;
     });
 
     test('of a single @A', () {
       expect($A.hasAnnotationOf($ExampleOfA), isTrue);
       final aAnnotation = $A.firstAnnotationOf($ExampleOfA)!;
-      expect(aAnnotation.type!.element3!.name3, 'A');
+      expect(aAnnotation.type!.element!.name, 'A');
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a multiple @A', () {
       final aAnnotations = $A.annotationsOf($ExampleOfMultiA);
-      expect(aAnnotations.map((a) => a.type!.element3!.name3), ['A', 'A']);
+      expect(aAnnotations.map((a) => a.type!.element!.name), ['A', 'A']);
       expect($B.annotationsOf($ExampleOfA), isEmpty);
       expect($C.annotationsOf($ExampleOfA), isEmpty);
     });
 
     test('of a single @A + single @B', () {
       final aAnnotations = $A.annotationsOf($ExampleOfAPlusB);
-      expect(aAnnotations.map((a) => a.type!.element3!.name3), ['A']);
+      expect(aAnnotations.map((a) => a.type!.element!.name), ['A']);
       final bAnnotations = $B.annotationsOf($ExampleOfAPlusB);
-      expect(bAnnotations.map((a) => a.type!.element3!.name3), ['B']);
+      expect(bAnnotations.map((a) => a.type!.element!.name), ['B']);
       expect($C.annotationsOf($ExampleOfAPlusB), isEmpty);
     });
 
     test('of a single @B + single @C', () {
       final cAnnotations = $C.annotationsOf($ExampleOfBPlusC);
-      expect(cAnnotations.map((a) => a.type!.element3!.name3), ['C']);
+      expect(cAnnotations.map((a) => a.type!.element!.name), ['C']);
       final bAnnotations = $B.annotationsOf($ExampleOfBPlusC);
-      expect(bAnnotations.map((a) => a.type!.element3!.name3), ['B', 'C']);
+      expect(bAnnotations.map((a) => a.type!.element!.name), ['B', 'C']);
       expect($B.hasAnnotationOfExact($ExampleOfBPlusC), isTrue);
       final bExact = $B.annotationsOfExact($ExampleOfBPlusC);
-      expect(bExact.map((a) => a.type!.element3!.name3), ['B']);
+      expect(bExact.map((a) => a.type!.element!.name), ['B']);
     });
   });
 
   group('unresolved annotations', () {
     late TypeChecker $A;
-    late ClassElement2 $ExampleOfA;
+    late ClassElement $ExampleOfA;
     late FormalParameterElement $annotatedParameter;
 
     setUpAll(() async {
@@ -613,16 +603,16 @@ void main() {
     ''', (resolver) async => (await resolver.findLibraryByName('_test'))!);
       $A = TypeChecker.fromStatic(
         library
-            .getClass2('A')!
+            .getClass('A')!
             .instantiate(
               typeArguments: [],
               nullabilitySuffix: NullabilitySuffix.none,
             ),
       );
-      $ExampleOfA = library.getClass2('ExampleOfA')!;
+      $ExampleOfA = library.getClass('ExampleOfA')!;
       $annotatedParameter =
           library.topLevelFunctions
-              .firstWhere((f) => f.name3 == 'annotatedParameter')
+              .firstWhere((f) => f.name == 'annotatedParameter')
               .formalParameters
               .single;
     });
@@ -667,28 +657,28 @@ void main() {
         $A
             .firstAnnotationOf($ExampleOfA, throwOnUnresolved: false)!
             .type!
-            .element3!
-            .name3,
+            .element!
+            .name,
         'A',
       );
       expect(
         $A
             .annotationsOf($ExampleOfA, throwOnUnresolved: false)
-            .map((a) => a.type!.element3!.name3),
+            .map((a) => a.type!.element!.name),
         ['A'],
       );
       expect(
         $A
             .firstAnnotationOfExact($ExampleOfA, throwOnUnresolved: false)!
             .type!
-            .element3!
-            .name3,
+            .element!
+            .name,
         'A',
       );
       expect(
         $A
             .annotationsOfExact($ExampleOfA, throwOnUnresolved: false)
-            .map((a) => a.type!.element3!.name3),
+            .map((a) => a.type!.element!.name),
         ['A'],
       );
     });

--- a/source_gen/test/utils_test.dart
+++ b/source_gen/test/utils_test.dart
@@ -6,15 +6,13 @@
 @Timeout.factor(2.0)
 library;
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build_test/build_test.dart';
 import 'package:source_gen/src/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  late ClassElement2 example;
+  late ClassElement example;
 
   setUpAll(() async {
     const source = r'''
@@ -32,17 +30,17 @@ void main() {
       source,
       (resolver) => resolver
           .findLibraryByName('example')
-          .then((e) => e!.getClass2('Example')!),
+          .then((e) => e!.getClass('Example')!),
     );
   });
 
   test('should return the name of a class type', () {
-    final classType = example.methods2.first.returnType;
+    final classType = example.methods.first.returnType;
     expect(typeNameOf(classType), 'ClassType');
   });
 
   test('should return the name of a function type', () {
-    final functionType = example.methods2.last.returnType;
+    final functionType = example.methods.last.returnType;
     expect(typeNameOf(functionType), 'FunctionType');
   });
 


### PR DESCRIPTION
Also deleted
```dart
    if (element case final Annotatable annotatable) {
      final annotations = annotatable.metadata2.annotations;
      if (annotations.isEmpty) {
        return null;
      }
    }
  ```
  from `source_gen/lib/src/type_checker.dart` because it repeated a check that was done a few lines later. 
    