### PR TITLE
Remove mirrors, release 4.0.0.

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 3.1.1-wip
+## 4.0.0
 
+- **Breaking Change**: remove `TypeChecker.fromRuntime`, use
+  `TypeChecker.typeNamed` instead. This removes all use of `dart:mirror`, so
+  builders using `source_gen` can be AOT compiled for better performance.
 - Keep `// GENERATED FILE` comments on the first line.
 
 ## 3.1.0

--- a/source_gen/lib/src/generator_for_annotation.dart
+++ b/source_gen/lib/src/generator_for_annotation.dart
@@ -58,9 +58,10 @@ abstract class GeneratorForAnnotation<T> extends Generator {
   /// annotations. You can override this by setting [throwOnUnresolved] to
   /// `false`.
   ///
-  /// With `source_gen` 4.0.0 this class will stop using mirrors for matching
-  /// annotations and will fall back to comparing the name of `T`. Pass
-  /// [inPackage] and [inSdk] to tighten the check; see [TypeChecker.typeNamed].
+  /// [TypeChecker.typeNamed] on `T` is used to match the annotation. By default
+  /// it matches any annotation with the same name. Pass [inPackage] and [inSdk]
+  /// to tighten the check; see [TypeChecker.typeNamed] for details.
+  ///
   /// To use a custom annotation check, override [typeChecker].
   const GeneratorForAnnotation({
     this.throwOnUnresolved = true,
@@ -68,9 +69,8 @@ abstract class GeneratorForAnnotation<T> extends Generator {
     this.inSdk,
   });
 
-  // This will switch to `typeNamed` in 4.0.0.
-  // ignore: deprecated_member_use_from_same_package
-  TypeChecker get typeChecker => TypeChecker.fromRuntime(T);
+  TypeChecker get typeChecker =>
+      TypeChecker.typeNamed(T, inPackage: inPackage, inSdk: inSdk);
 
   @override
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -4,8 +4,6 @@
 
 // ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
 
-import 'dart:mirrors' hide SourceLocation;
-
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
@@ -33,20 +31,6 @@ abstract class TypeChecker {
   /// const $FooOrBar = const TypeChecker.forAny(const [$Foo, $Bar]);
   /// ```
   const factory TypeChecker.any(Iterable<TypeChecker> checkers) = _AnyChecker;
-
-  /// Create a new [TypeChecker] backed by a runtime [type].
-  ///
-  /// This implementation uses `dart:mirrors` (runtime reflection).
-  @Deprecated('''
-Will be removed in 4.0.0 to drop `dart:mirrors` dependency.
-
-Recommended: replace `fromRuntime(Foo)` with
-`typeNamed(Foo, inPackage: 'foo_package')`. This is a slighly weaker check than
-`fromRuntime(Foo)` as it matches any annotation named `Foo` in
-`package:foo_package`.
-
-If you need an exact match, use `fromUrl`.''')
-  const factory TypeChecker.fromRuntime(Type type) = _MirrorTypeChecker;
 
   /// Create a new [TypeChecker] for types matching the name of [type].
   ///
@@ -265,29 +249,6 @@ class _LibraryTypeChecker extends TypeChecker {
 
   @override
   String toString() => urlOfElement(_type.element3!);
-}
-
-// Checks a runtime type against a static type.
-class _MirrorTypeChecker extends TypeChecker {
-  static Uri _uriOf(ClassMirror mirror) => normalizeUrl(
-    (mirror.owner as LibraryMirror).uri,
-  ).replace(fragment: MirrorSystem.getName(mirror.simpleName));
-
-  // Precomputed type checker for types that already have been used.
-  static final _cache = Expando<TypeChecker>();
-
-  final Type _type;
-
-  const _MirrorTypeChecker(this._type) : super._();
-
-  TypeChecker get _computed =>
-      _cache[this] ??= TypeChecker.fromUrl(_uriOf(reflectClass(_type)));
-
-  @override
-  bool isExactly(Element2 element) => _computed.isExactly(element);
-
-  @override
-  String toString() => _computed.toString();
 }
 
 // Checks a runtime type name and optional package against a static type.

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 3.1.1-wip
+version: 4.0.0
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -334,32 +334,6 @@ void main() {
     });
   }
 
-  group('TypeChecker.forRuntime', () {
-    commonTests(
-      // ignore: deprecated_member_use_from_same_package
-      checkIterable: () => const TypeChecker.fromRuntime(Iterable),
-      // ignore: deprecated_member_use_from_same_package
-      checkEnum: () => const TypeChecker.fromRuntime(Enum),
-      // ignore: deprecated_member_use_from_same_package
-      checkEnumMixin: () => const TypeChecker.fromRuntime(MyEnumMixin),
-      // ignore: deprecated_member_use_from_same_package
-      checkMap: () => const TypeChecker.fromRuntime(Map),
-      // ignore: deprecated_member_use_from_same_package
-      checkMapMixin: () => const TypeChecker.fromRuntime(MyMapMixin),
-      // ignore: deprecated_member_use_from_same_package
-      checkHashMap: () => const TypeChecker.fromRuntime(HashMap),
-      // ignore: deprecated_member_use_from_same_package
-      checkGenerator: () => const TypeChecker.fromRuntime(Generator),
-
-      checkGeneratorForAnnotation:
-          // ignore: deprecated_member_use_from_same_packages
-          () => const TypeChecker.typeNamed(
-            GeneratorForAnnotation,
-            inPackage: 'source_gen',
-          ),
-    );
-  });
-
   group('TypeChecker.typeNamed without package', () {
     commonTests(
       checkIterable: () => const TypeChecker.typeNamed(Iterable),


### PR DESCRIPTION
For #775 

Bump to version 4, remove deprecated methods that were using mirrors.