### PR TITLE
Add TypeChecker.typeNamedLiterally.

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.0
+
+- Add `TypeChecker.typeNamedLiterally`. It's like `TypeChecker.typeNamed`,
+  but takes a `String` instead of a `Type`.
+
 ## 4.0.2
 
 - Bug fix: fix possible null pointer exception in `TypeChecker.typeNamed` on

--- a/source_gen/lib/src/type_checker.dart
+++ b/source_gen/lib/src/type_checker.dart
@@ -40,6 +40,16 @@ abstract class TypeChecker {
     bool? inSdk,
   }) = _NameTypeChecker;
 
+  /// Create a new [TypeChecker] for types with name exactly [name].
+  ///
+  /// Optionally, also pass [inPackage] to restrict to a specific package by
+  /// name. Set [inSdk] if it's a `dart` package.
+  const factory TypeChecker.typeNamedLiterally(
+    String name, {
+    String? inPackage,
+    bool? inSdk,
+  }) = _LiteralNameTypeChecker;
+
   /// Create a new [TypeChecker] backed by a static [type].
   const factory TypeChecker.fromStatic(DartType type) = _LibraryTypeChecker;
 
@@ -268,6 +278,21 @@ class _NameTypeChecker extends TypeChecker {
 
   @override
   String toString() => _inPackage == null ? '$_type' : '$_inPackage#$_type';
+}
+
+// [_NameTypeChecker] that ignores the `Type` and uses a `String` name.
+class _LiteralNameTypeChecker extends _NameTypeChecker {
+  @override
+  final String _typeName;
+
+  const _LiteralNameTypeChecker(
+    this._typeName, {
+    String? inPackage,
+    bool? inSdk,
+  }) : super(Object, inPackage: inPackage, inSdk: inSdk);
+
+  @override
+  String toString() => _inPackage == null ? '$_type' : '$_inPackage#$_typeName';
 }
 
 // Checks a runtime type against an Uri and Symbol.

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 4.0.2
+version: 4.1.0
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/type_checker_test.dart
+++ b/source_gen/test/type_checker_test.dart
@@ -390,6 +390,69 @@ void main() {
     );
   });
 
+  group('TypeChecker.typeNamedLiterally without package', () {
+    commonTests(
+      checkIterable: () => const TypeChecker.typeNamedLiterally('Iterable'),
+      checkEnum: () => const TypeChecker.typeNamedLiterally('Enum'),
+      checkEnumMixin: () => const TypeChecker.typeNamedLiterally('MyEnumMixin'),
+      checkMap: () => const TypeChecker.typeNamedLiterally('Map'),
+      checkMapMixin: () => const TypeChecker.typeNamedLiterally('MyMapMixin'),
+      checkHashMap: () => const TypeChecker.typeNamedLiterally('HashMap'),
+      checkGenerator: () => const TypeChecker.typeNamedLiterally('Generator'),
+      checkGeneratorForAnnotation:
+          () => const TypeChecker.typeNamedLiterally('GeneratorForAnnotation'),
+    );
+  });
+
+  group('TypeChecker.typeNamedLiterally with package', () {
+    commonTests(
+      checkIterable:
+          () => const TypeChecker.typeNamedLiterally(
+            'Iterable',
+            inPackage: 'core',
+            inSdk: true,
+          ),
+      checkEnum:
+          () => const TypeChecker.typeNamedLiterally(
+            'Enum',
+            inPackage: 'core',
+            inSdk: true,
+          ),
+      checkEnumMixin:
+          () => const TypeChecker.typeNamedLiterally(
+            'MyEnumMixin',
+            inPackage: 'source_gen',
+          ),
+      checkMap:
+          () => const TypeChecker.typeNamedLiterally(
+            'Map',
+            inPackage: 'core',
+            inSdk: true,
+          ),
+      checkMapMixin:
+          () => const TypeChecker.typeNamedLiterally(
+            'MyMapMixin',
+            inPackage: 'source_gen',
+          ),
+      checkHashMap:
+          () => const TypeChecker.typeNamedLiterally(
+            'HashMap',
+            inPackage: 'collection',
+            inSdk: true,
+          ),
+      checkGenerator:
+          () => const TypeChecker.typeNamedLiterally(
+            'Generator',
+            inPackage: 'source_gen',
+          ),
+      checkGeneratorForAnnotation:
+          () => const TypeChecker.typeNamedLiterally(
+            'GeneratorForAnnotation',
+            inPackage: 'source_gen',
+          ),
+    );
+  });
+
   group('TypeChecker.forStatic', () {
     commonTests(
       checkIterable: () => staticIterableChecker,


### PR DESCRIPTION
Fix #795 

Not really sure on the name, "typeName" is already taken and because it's a const constructor there isn't really a way to make it do more stuff.