### PR TITLE
Update example commands to use 'dart run' rather than `pub run`

### DIFF
--- a/example_usage/README.md
+++ b/example_usage/README.md
@@ -7,7 +7,7 @@ See also the `example` directory containing the builders used in this package.
 In this directory, run:
 
 ```console
-$ pub get
+$ dart pub get
 ...
-$ pub run build_runner build
+$ dart run build_runner build
 ```


### PR DESCRIPTION
Re https://github.com/dart-lang/pub/issues/4737