### PR TITLE
Replace pub run with dart run

### DIFF
--- a/example_usage/README.md
+++ b/example_usage/README.md
@@ -9,5 +9,5 @@ In this directory, run:
 ```console
 $ pub get
 ...
-$ pub run build_runner build
+$ dart run build_runner build
 ```


### PR DESCRIPTION
Following up on https://github.com/dart-lang/pub/issues/4737, this PR replaces deprecated `pub run` commands with `dart run`.