### PR TITLE
fix: correct partId validation error message

### DIFF
--- a/source_gen/lib/src/builder.dart
+++ b/source_gen/lib/src/builder.dart
@@ -255,8 +255,7 @@ class SharedPartBuilder extends _Builder {
       throw ArgumentError.value(
         partId,
         'partId',
-        '`partId` can only contain letters, numbers, `_` and `.`. '
-            'It cannot start or end with `.`.',
+        '`partId` can only contain letters, numbers, `_` and `-`.',
       );
     }
   }

--- a/source_gen/test/builder_test.dart
+++ b/source_gen/test/builder_test.dart
@@ -547,6 +547,32 @@ part "a.foo.dart";''',
           );
         });
       }
+
+      test('accepts partId with hyphens', () {
+        expect(
+          () => SharedPartBuilder([
+            const UnformattedCodeGenerator(),
+          ], 'my-part'),
+          returnsNormally,
+        );
+      });
+
+      test('error message matches allowed characters', () {
+        try {
+          SharedPartBuilder([
+            const UnformattedCodeGenerator(),
+          ], 'invalid!id');
+          fail('Should have thrown');
+        } on ArgumentError catch (e) {
+          final message = e.message as String;
+          // The error message should mention hyphens since the regex
+          // allows them (issue #607).
+          expect(message, contains('-'));
+          // The error message should NOT mention `.` since the regex
+          // does not allow periods.
+          expect(message, isNot(contains('`.`')));
+        }
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixed the error message in `SharedPartBuilder` to correctly describe the allowed characters for `partId`: letters, numbers, `_`, and `-`
- The previous message incorrectly mentioned `.` (period) as an allowed character and referenced start/end rules that do not exist in the regex

Fixes #607

## Test plan
- All 63 existing tests pass
- Added test verifying that hyphens are accepted in partId
- Added test verifying the error message mentions `-` and does not mention `.`