### PR TITLE
Explain why a value cannot be revived

### DIFF
--- a/source_gen/CHANGELOG.md
+++ b/source_gen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.2.5-wip
+
+- Throw an `UnsupportedError` explaining the problem, instead of
+  `Bad state: No element`, when `ConstantReader.revive()` finds no candidate to
+  revive. This may be breaking if a builder catches the `StateError`.
+
 ## 4.2.4
 
 - Require `analyzer: '>=8.1.1 <15.0.0'`

--- a/source_gen/lib/src/constants/reader.dart
+++ b/source_gen/lib/src/constants/reader.dart
@@ -111,9 +111,9 @@ abstract class ConstantReader {
   /// and code generators will want to figure out how to "recreate" a constant
   /// at runtime.
   ///
-  /// Throws an [UnsupportedError] for a null constant, and when the value has
-  /// no reference to recreate: read a literal with [literalValue] and a type
-  /// with [typeValue] instead.
+  /// Throws an [UnsupportedError] for a null constant, and when the search for
+  /// a reference to the value comes up empty: read a literal with
+  /// [literalValue] and a type with [typeValue] instead.
   Revivable revive();
 }
 

--- a/source_gen/lib/src/constants/reader.dart
+++ b/source_gen/lib/src/constants/reader.dart
@@ -110,6 +110,9 @@ abstract class ConstantReader {
   /// This is appropriate for cases where the underlying object is not a literal
   /// and code generators will want to figure out how to "recreate" a constant
   /// at runtime.
+  ///
+  /// Throws an [UnsupportedError] when there is no reference to recreate: read
+  /// a literal with [literalValue] and a type with [typeValue] instead.
   Revivable revive();
 }
 

--- a/source_gen/lib/src/constants/reader.dart
+++ b/source_gen/lib/src/constants/reader.dart
@@ -111,8 +111,9 @@ abstract class ConstantReader {
   /// and code generators will want to figure out how to "recreate" a constant
   /// at runtime.
   ///
-  /// Throws an [UnsupportedError] when there is no reference to recreate: read
-  /// a literal with [literalValue] and a type with [typeValue] instead.
+  /// Throws an [UnsupportedError] for a null constant, and when the value has
+  /// no reference to recreate: read a literal with [literalValue] and a type
+  /// with [typeValue] instead.
   Revivable revive();
 }
 

--- a/source_gen/lib/src/constants/revive.dart
+++ b/source_gen/lib/src/constants/revive.dart
@@ -12,9 +12,9 @@ import '../utils.dart';
 
 /// Attempts to extract what source code could be used to represent [object].
 ///
-/// Returns `null` if it wasn't possible to parse [object], or [object] is a
-/// primitive value (such as a number, string, boolean) that does not need to be
-/// revived in order to represent it.
+/// Throws an [UnsupportedError] when the search for a reference to [object]
+/// comes up empty: a literal is read with `ConstantReader.literalValue` and a
+/// type with `ConstantReader.typeValue` instead.
 ///
 /// **NOTE**: Some returned [Revivable] instances are not representable as valid
 /// Dart source code (such as referencing private constructors). It is up to the
@@ -100,6 +100,14 @@ Revivable reviveInstance(DartObject object, [LibraryElement? origin]) {
     if (tryResult(result)) {
       return result;
     }
+  }
+  if (allResults.isEmpty) {
+    throw UnsupportedError(
+      'Cannot revive $object: it is not a const constructor invocation, and '
+      'no constant declaration for it was found in $origin. Read a literal '
+      'with `ConstantReader.literalValue` and a type with '
+      '`ConstantReader.typeValue`.',
+    );
   }
   // We could try and return the "best" result more intelligently.
   return allResults.first;

--- a/source_gen/pubspec.yaml
+++ b/source_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen
-version: 4.2.4
+version: 4.2.5-wip
 description: >-
   Source code generation builders and utilities for the Dart build system
 repository: https://github.com/dart-lang/source_gen/tree/master/source_gen

--- a/source_gen/test/constants_test.dart
+++ b/source_gen/test/constants_test.dart
@@ -229,6 +229,7 @@ void main() {
         @_privateField
         @Wrapper(_privateFunction)
         @ProcessStartMode.normal
+        @TypeWrapper(String)
         class Example {}
 
         class Int64Like implements Int64LikeBase{
@@ -298,6 +299,11 @@ void main() {
         }
 
         void _privateFunction() {}
+
+        class TypeWrapper {
+          final Type t;
+          const TypeWrapper(this.t);
+        }
       ''', (resolver) async => (await resolver.findLibraryByName('test_lib'))!);
       constants = library
           .getClass('Example')!
@@ -396,5 +402,18 @@ void main() {
         expect(staticFieldWithPrivateImpl.source.fragment, isEmpty);
       },
     );
+
+    test('should explain why a type literal cannot be revived', () {
+      expect(
+        () => constants[14].read('t').revive(),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            contains('ConstantReader.typeValue'),
+          ),
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes #411

`reviveInstance` ends with `allResults.first`, and that list is empty whenever it finds no candidate:

```
Bad state: No element
dart:core                                             List.first
package:source_gen/src/constants/revive.dart 105:21   reviveInstance
package:source_gen/src/constants/reader.dart 278:25   _DartObjectConstant.revive
```

`revive()` never passes an `origin`, so the scan runs over the library of the value's own type. That library is `dart:core` for a literal or a type, never the one the annotation was written in.

```
Unsupported operation: Cannot revive Type (String): it is not a const
constructor invocation, and no constant declaration for it was found in
library dart:core. Read a literal with `ConstantReader.literalValue` and
a type with `ConstantReader.typeValue`.
```

`UnsupportedError` is what @TekExplorer suggested, and what `revive()` already throws for a null constant. The dartdoc promised `null` here, which the non-nullable return never allowed; it now says what happens.

I looked for callers that catch the `StateError`. `analyzer_buffer`, the one #411 points to, catches everything with a bare `catch`, so only the text it wraps changes. `mockito` resolves this version but calls `revive()` after ruling out null, literals, and types (`_addTypesFromConstant` in `builder.dart`). `sql_serializable` branches on the error type (`config.dart:136`) but pins `source_gen: ^1.2.6`.

Version goes to `4.2.5-wip`.